### PR TITLE
[codex] Fix monitoring log table layout

### DIFF
--- a/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.module.scss
+++ b/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.module.scss
@@ -3041,7 +3041,7 @@
 }
 
 .realtimeTable {
-  min-width: 1360px;
+  min-width: 1392px;
   table-layout: fixed;
 }
 
@@ -3086,7 +3086,7 @@
 }
 
 .realtimeUsageCol {
-  width: 140px;
+  width: 172px;
 }
 
 .realtimeCostCol {
@@ -3177,6 +3177,10 @@
   line-height: 1.45;
 }
 
+.realtimeTable tbody td {
+  vertical-align: middle;
+}
+
 .table tbody td:first-child {
   border-left: 0;
   border-radius: 0;
@@ -3215,6 +3219,34 @@
 .primaryCell span {
   font-size: 13px;
   font-weight: 600;
+}
+
+.realtimeTimeCell {
+  white-space: normal;
+  line-height: 1.35;
+}
+
+.realtimeUsageCell {
+  gap: 6px;
+}
+
+.realtimeUsageBreakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.realtimeUsageBreakdown span {
+  flex: 0 0 auto;
+  overflow: visible;
+  text-overflow: clip;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  white-space: nowrap;
 }
 
 .primaryCell small,
@@ -3648,12 +3680,17 @@
   gap: 2px;
 }
 
-.realtimeTable td:nth-child(11) .primaryCell span,
-.realtimeTable td:nth-child(11) .primaryCell small {
+.realtimeTable td:nth-child(11) .primaryCell > span,
+.realtimeTable td:nth-child(11) .primaryCell > small {
   display: block;
   white-space: nowrap;
   overflow-wrap: normal;
   word-break: normal;
+}
+
+.realtimeTable td:nth-child(11) .realtimeUsageBreakdown {
+  display: flex;
+  white-space: normal;
 }
 
 .logRowFailed td {

--- a/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.tsx
+++ b/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.tsx
@@ -3669,11 +3669,16 @@ export function MonitoringCenterPage() {
                       {formatDurationMs(row.latencyMs, { locale: i18n.language })}
                     </span>
                   </td>
-                  <td>{new Date(row.timestampMs).toLocaleString(i18n.language)}</td>
+                  <td className={styles.realtimeTimeCell}>{new Date(row.timestampMs).toLocaleString(i18n.language)}</td>
                   <td>
-                    <div className={styles.primaryCell}>
+                    <div className={`${styles.primaryCell} ${styles.realtimeUsageCell}`}>
                       <span>{formatCompactNumber(row.totalTokens)}</span>
-                      <small>{`I ${formatCompactNumber(row.inputTokens)} · O ${formatCompactNumber(row.outputTokens)} · R ${formatCompactNumber(row.reasoningTokens)} · C ${formatCompactNumber(row.cachedTokens)}`}</small>
+                      <small className={styles.realtimeUsageBreakdown}>
+                        <span>{`I ${formatCompactNumber(row.inputTokens)}`}</span>
+                        <span>{`O ${formatCompactNumber(row.outputTokens)}`}</span>
+                        <span>{`R ${formatCompactNumber(row.reasoningTokens)}`}</span>
+                        <span>{`C ${formatCompactNumber(row.cachedTokens)}`}</span>
+                      </small>
                     </div>
                   </td>
                   <td>{hasPrices ? formatUsd(row.totalCost) : '--'}</td>


### PR DESCRIPTION
## Summary
- vertically center realtime log table cells so the time column no longer sits at the top of tall rows
- split per-call usage into wrapped I/O/R/C token chips so reasoning and cache values remain visible
- widen the realtime usage column while preserving horizontal scrolling for compact viewports

## Validation
- `git diff --check`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('cliproxyapi-pro-management/monitoring-locales.json','utf8')); for (const [locale, dict] of Object.entries(data)) { if (!dict.monitoring?.column_ttft || !dict.monitoring?.column_latency) throw new Error(locale+' missing latency columns'); } console.log('monitoring-locales.json OK');"`
- visual preview rendered locally from the monitoring log table layout slice

Note: this repository stores the management overlay, not the full upstream frontend checkout, so local `npm run type-check`/`build` is not available without applying the overlay to an upstream management checkout.
