### PR TITLE
[codex] Improve usage token label spacing

### DIFF
--- a/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.module.scss
+++ b/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.module.scss
@@ -3240,13 +3240,27 @@
 }
 
 .realtimeUsageBreakdown span {
+  display: inline-flex;
+  align-items: baseline;
   flex: 0 0 auto;
+  gap: 3px;
   overflow: visible;
   text-overflow: clip;
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
   white-space: nowrap;
+}
+
+.realtimeUsageBreakdown > span:not(:last-child)::after {
+  content: '·';
+  margin-left: 5px;
+  color: color-mix(in srgb, var(--monitor-muted) 70%, transparent);
+}
+
+.realtimeUsageBreakdown b {
+  color: var(--monitor-ink);
+  font-weight: 700;
 }
 
 .primaryCell small,

--- a/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.tsx
+++ b/cliproxyapi-pro-management/overlay/src/pages/MonitoringCenterPage.tsx
@@ -3674,10 +3674,10 @@ export function MonitoringCenterPage() {
                     <div className={`${styles.primaryCell} ${styles.realtimeUsageCell}`}>
                       <span>{formatCompactNumber(row.totalTokens)}</span>
                       <small className={styles.realtimeUsageBreakdown}>
-                        <span>{`I ${formatCompactNumber(row.inputTokens)}`}</span>
-                        <span>{`O ${formatCompactNumber(row.outputTokens)}`}</span>
-                        <span>{`R ${formatCompactNumber(row.reasoningTokens)}`}</span>
-                        <span>{`C ${formatCompactNumber(row.cachedTokens)}`}</span>
+                        <span><b>I</b><span>{formatCompactNumber(row.inputTokens)}</span></span>
+                        <span><b>O</b><span>{formatCompactNumber(row.outputTokens)}</span></span>
+                        <span><b>R</b><span>{formatCompactNumber(row.reasoningTokens)}</span></span>
+                        <span><b>C</b><span>{formatCompactNumber(row.cachedTokens)}</span></span>
                       </small>
                     </div>
                   </td>


### PR DESCRIPTION
## Summary
- render per-call usage details as separated label/value groups
- add item separators so I/O/R/C values no longer visually run together

## Validation
- `git diff --check`

Note: this repository stores the management overlay, not the full upstream frontend checkout, so local `npm run type-check`/`build` is not available without applying the overlay to an upstream management checkout.
