### PR TITLE
Harden persisted state and backup recovery

### DIFF
--- a/cliproxyapi-pro-core/README.md
+++ b/cliproxyapi-pro-core/README.md
@@ -65,17 +65,19 @@ internal/embeddedusage
 
 ### JSONL usage 备份与恢复
 
-`/usage/export` 返回 `application/x-ndjson`，一行一个 JSON 对象。
+`/usage/export` 返回 `application/x-ndjson`，一行一个 JSON 对象。新导出的第一行是 `backup_manifest`，记录后续行数和 SHA-256；导入会在任何数据库写入前校验完整文件，因此截断或篡改的备份会被整体拒绝。
 
 导出内容包含 usage events，也可能包含元数据记录：
 
 - `model_prices` — 基础价格兼容数据和完整 provider/model 价格规则。
 - `quota_cache` — 配额卡片和账号级刷新使用的 SQLite-backed quota snapshots。
 - `monitoring_settings` — 监控日志保留时间、WebDAV 备份配置和 models.dev 定期同步配置。
+- `routing_cursor_state` — 账号路由轮转游标。
+- `auth_runtime_stats` — 账号选择、成功/失败和近期请求桶统计。
 - `account_inspection_schedule` — 后端账号巡检调度设置。
 - `account_inspection_snapshot` — 最近一次已结束的账号巡检结果，包含运行设置、汇总、健康统计、完整结果和原始错误详情，不包含巡检日志。
 
-`/usage/import` 接受同样的 JSONL 格式。导入时会对每行只读取一次 `record_type`，导入 usage events，恢复模型价格、quota cache entries、监控设置、账号巡检调度和最近一次巡检结果快照。恢复的结果快照为只读；发起新的完整巡检后才允许重检、刷新令牌或执行账号变更。
+`/usage/import` 接受同样的 JSONL 格式。导入时会先完整读取和校验请求，再导入 usage events，恢复模型价格、quota cache entries、运行时路由状态、监控设置、账号巡检调度和最近一次巡检结果快照。路由游标与账号运行统计在同一个 SQLite 事务中恢复。恢复的结果快照为只读；发起新的完整巡检后才允许重检、刷新令牌或执行账号变更。旧版无 manifest 的 event-only 或混合 JSONL 仍可导入，但无法获得文件级完整性校验。
 
 导入响应示例字段：
 

--- a/cliproxyapi-pro-core/README_EN.md
+++ b/cliproxyapi-pro-core/README_EN.md
@@ -65,17 +65,19 @@ Details returned by `/usage/events` and `/usage/stream` include a stable event `
 
 ### JSONL usage backup and restore
 
-`/usage/export` returns `application/x-ndjson`, one JSON object per line.
+`/usage/export` returns `application/x-ndjson`, one JSON object per line. New exports start with a `backup_manifest` that records the following line count and SHA-256. Import verifies the complete file before any database write, so truncated or modified backups are rejected as a unit.
 
 The export contains usage events and may also include metadata records:
 
 - `model_prices` — legacy base prices plus complete provider/model pricing rules.
 - `quota_cache` — SQLite-backed quota snapshots used by quota cards and account-scoped refresh.
 - `monitoring_settings` — retention, WebDAV backup, and scheduled models.dev synchronization settings.
+- `routing_cursor_state` — account-routing rotation cursors.
+- `auth_runtime_stats` — account selection, success/failure, and recent-request-bucket statistics.
 - `account_inspection_schedule` — persisted backend account-inspection schedule.
 - `account_inspection_snapshot` — the latest finished inspection result, including run settings, summary, health counts, complete results, and raw error details, but excluding inspection logs.
 
-`/usage/import` accepts the same JSONL format. It reads each line's `record_type` once, imports usage events, and restores model prices, quota cache entries, monitoring settings, the account-inspection schedule, and the latest inspection-result snapshot when present. A restored result snapshot is read-only until a new full inspection runs. Older event-only JSONL files remain compatible.
+`/usage/import` accepts the same JSONL format. It reads and verifies the complete request before writing, then imports usage events and restores model prices, quota cache entries, routing runtime state, monitoring settings, the account-inspection schedule, and the latest inspection-result snapshot when present. Routing cursors and account runtime statistics are restored in one SQLite transaction. A restored result snapshot is read-only until a new full inspection runs. Older manifest-free event-only and mixed JSONL files remain compatible, but cannot receive file-level integrity verification.
 
 Example import response fields:
 

--- a/cliproxyapi-pro-core/embeddedusage/global.go
+++ b/cliproxyapi-pro-core/embeddedusage/global.go
@@ -18,6 +18,9 @@ var globalStateMu sync.RWMutex
 var globalStateWriterCancel context.CancelFunc
 var globalStateWriterDone chan struct{}
 var globalStateQueue chan runtimeStateMutation
+var globalStateOverflowMu sync.Mutex
+var globalStateOverflowCursors map[string]RoutingCursorState
+var globalStateOverflowStats map[string]AuthRuntimeStats
 
 type runtimeStateMutation struct {
 	cursor *RoutingCursorState
@@ -38,17 +41,17 @@ func SetDefaultService(service *Service) {
 	globalStateMu.Lock()
 	if globalStateWriterCancel != nil {
 		globalStateWriterCancel()
-		globalStateWriterCancel = nil
 	}
+	if globalStateWriterDone != nil {
+		<-globalStateWriterDone
+	}
+	globalStateWriterCancel = nil
 	globalService = service
 	globalStateQueue = nil
 	globalStateWriterDone = nil
+	resetRuntimeStateOverflow()
 	if service != nil && service.store != nil {
-		parent := service.ctx
-		if parent == nil {
-			parent = context.Background()
-		}
-		ctx, cancel := context.WithCancel(parent)
+		ctx, cancel := context.WithCancel(context.Background())
 		globalStateWriterCancel = cancel
 		globalStateWriterDone = make(chan struct{})
 		globalStateQueue = make(chan runtimeStateMutation, 1024)
@@ -84,17 +87,39 @@ func runRuntimeStateWriter(ctx context.Context, store *Store, queue <-chan runti
 			}
 		}
 	}
+	drainOverflow := func() {
+		globalStateOverflowMu.Lock()
+		overflowCursors := globalStateOverflowCursors
+		overflowStats := globalStateOverflowStats
+		globalStateOverflowCursors = make(map[string]RoutingCursorState)
+		globalStateOverflowStats = make(map[string]AuthRuntimeStats)
+		globalStateOverflowMu.Unlock()
+		for _, state := range overflowCursors {
+			state := state
+			merge(runtimeStateMutation{cursor: &state})
+		}
+		for _, item := range overflowStats {
+			item := item
+			merge(runtimeStateMutation{stats: &item})
+		}
+	}
 	flush := func() error {
 		var firstErr error
 		for key, state := range cursors {
-			if err := store.SetRoutingCursorState(context.Background(), state); err != nil && firstErr == nil {
-				firstErr = err
+			if err := store.SetRoutingCursorState(context.Background(), state); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			delete(cursors, key)
 		}
 		for key, item := range stats {
-			if err := store.SetAuthRuntimeStats(context.Background(), item); err != nil && firstErr == nil {
-				firstErr = err
+			if err := store.SetAuthRuntimeStats(context.Background(), item); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			delete(stats, key)
 		}
@@ -102,6 +127,7 @@ func runRuntimeStateWriter(ctx context.Context, store *Store, queue <-chan runti
 	}
 	process := func(mutation runtimeStateMutation) {
 		if mutation.flush != nil {
+			drainOverflow()
 			mutation.flush <- flush()
 			close(mutation.flush)
 			return
@@ -110,16 +136,33 @@ func runRuntimeStateWriter(ctx context.Context, store *Store, queue <-chan runti
 			merge(mutation)
 			return
 		}
+		drainOverflow()
 		flushErr := flush()
-		err := store.DeleteAuthRuntimeState(context.Background(), mutation.delete.authID, mutation.delete.authIndex, mutation.delete.fileName)
+		deleteErr := store.DeleteAuthRuntimeState(context.Background(), mutation.delete.authID, mutation.delete.authIndex, mutation.delete.fileName)
+		if deleteErr == nil {
+			for key, item := range stats {
+				if runtimeStateMatchesDelete(item, mutation.delete) {
+					delete(stats, key)
+				}
+			}
+			if mutation.delete.authIndex != "" {
+				deletedAt[mutation.delete.authIndex] = mutation.delete.updatedAt
+			}
+		}
+		err := deleteErr
 		if err == nil {
 			err = flushErr
 		}
-		if mutation.delete.authIndex != "" {
-			deletedAt[mutation.delete.authIndex] = mutation.delete.updatedAt
-		}
 		mutation.delete.done <- err
 		close(mutation.delete.done)
+	}
+	flushBeforeStop := func() {
+		for attempt := 0; attempt < 5; attempt++ {
+			if err := flush(); err == nil {
+				return
+			}
+			time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+		}
 	}
 	for {
 		select {
@@ -129,16 +172,51 @@ func runRuntimeStateWriter(ctx context.Context, store *Store, queue <-chan runti
 				case mutation := <-queue:
 					process(mutation)
 				default:
-					_ = flush()
+					drainOverflow()
+					flushBeforeStop()
 					return
 				}
 			}
 		case mutation := <-queue:
 			process(mutation)
 		case <-ticker.C:
+			drainOverflow()
 			_ = flush()
 		}
 	}
+}
+
+func resetRuntimeStateOverflow() {
+	globalStateOverflowMu.Lock()
+	globalStateOverflowCursors = make(map[string]RoutingCursorState)
+	globalStateOverflowStats = make(map[string]AuthRuntimeStats)
+	globalStateOverflowMu.Unlock()
+}
+
+func mergeRuntimeStateOverflow(mutation runtimeStateMutation) {
+	globalStateOverflowMu.Lock()
+	defer globalStateOverflowMu.Unlock()
+	if mutation.cursor != nil {
+		current, ok := globalStateOverflowCursors[mutation.cursor.CursorKey]
+		if !ok || mutation.cursor.UpdatedAtMS >= current.UpdatedAtMS {
+			globalStateOverflowCursors[mutation.cursor.CursorKey] = *mutation.cursor
+		}
+	}
+	if mutation.stats != nil {
+		current, ok := globalStateOverflowStats[mutation.stats.AuthIndex]
+		if !ok || mutation.stats.UpdatedAtMS >= current.UpdatedAtMS {
+			globalStateOverflowStats[mutation.stats.AuthIndex] = *mutation.stats
+		}
+	}
+}
+
+func runtimeStateMatchesDelete(item AuthRuntimeStats, deletion *runtimeStateDelete) bool {
+	if deletion == nil {
+		return false
+	}
+	return (deletion.authIndex != "" && item.AuthIndex == deletion.authIndex) ||
+		(deletion.authID != "" && item.AuthID == deletion.authID) ||
+		(deletion.fileName != "" && item.FileName == deletion.fileName)
 }
 
 func stopRuntimeStateWriter(service *Service) {
@@ -147,32 +225,31 @@ func stopRuntimeStateWriter(service *Service) {
 		globalStateMu.Unlock()
 		return
 	}
-	cancel := globalStateWriterCancel
-	done := globalStateWriterDone
+	if globalStateWriterCancel != nil {
+		globalStateWriterCancel()
+	}
+	if globalStateWriterDone != nil {
+		<-globalStateWriterDone
+	}
 	globalStateWriterCancel = nil
 	globalStateWriterDone = nil
 	globalStateQueue = nil
 	globalService = nil
+	resetRuntimeStateOverflow()
 	globalStateMu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
-	if done != nil {
-		<-done
-	}
 }
 
 func enqueueRuntimeState(mutation runtimeStateMutation) {
 	globalStateMu.RLock()
+	defer globalStateMu.RUnlock()
 	queue := globalStateQueue
-	globalStateMu.RUnlock()
 	if queue == nil {
 		return
 	}
 	select {
 	case queue <- mutation:
 	default:
-		// The next result/selection snapshot is cumulative and will supersede this one.
+		mergeRuntimeStateOverflow(mutation)
 	}
 }
 
@@ -181,11 +258,11 @@ func flushRuntimeStateWrites(ctx context.Context, store *Store) error {
 		ctx = context.Background()
 	}
 	globalStateMu.RLock()
+	defer globalStateMu.RUnlock()
 	var queue chan runtimeStateMutation
 	if globalService != nil && globalService.store == store {
 		queue = globalStateQueue
 	}
-	globalStateMu.RUnlock()
 	if queue == nil {
 		return nil
 	}
@@ -295,9 +372,9 @@ func GetAuthRuntimeStats(ctx context.Context, authIndex, authID string) (AuthRun
 
 func DeleteAuthRuntimeState(ctx context.Context, authID, authIndex, fileName string) error {
 	globalStateMu.RLock()
+	defer globalStateMu.RUnlock()
 	service := globalService
 	queue := globalStateQueue
-	globalStateMu.RUnlock()
 	if service == nil || service.store == nil {
 		return nil
 	}

--- a/cliproxyapi-pro-core/embeddedusage/internalusage/event.go
+++ b/cliproxyapi-pro-core/embeddedusage/internalusage/event.go
@@ -632,6 +632,7 @@ func buildEventHash(event Event) string {
 		event.Model,
 		event.AuthIndex,
 		event.SourceHash,
+		event.APIKeyHash,
 		strconv.FormatInt(event.InputTokens, 10),
 		strconv.FormatInt(event.OutputTokens, 10),
 		strconv.FormatInt(event.ReasoningTokens, 10),

--- a/cliproxyapi-pro-core/embeddedusage/internalusage/event_test.go
+++ b/cliproxyapi-pro-core/embeddedusage/internalusage/event_test.go
@@ -113,6 +113,34 @@ func TestNormalizeRawPreservesExportedHashes(t *testing.T) {
 	}
 }
 
+func TestNormalizeRawEventHashSeparatesAPIKeys(t *testing.T) {
+	first, err := NormalizeRaw([]byte(`{
+		"timestamp":"2026-06-13T00:00:00Z",
+		"request_id":"req-shared",
+		"endpoint":"POST /v1/chat/completions",
+		"model":"gpt-test",
+		"api_key":"sk-first",
+		"tokens":{"input_tokens":10,"output_tokens":20}
+	}`))
+	if err != nil {
+		t.Fatalf("NormalizeRaw(first) error = %v", err)
+	}
+	second, err := NormalizeRaw([]byte(`{
+		"timestamp":"2026-06-13T00:00:00Z",
+		"request_id":"req-shared",
+		"endpoint":"POST /v1/chat/completions",
+		"model":"gpt-test",
+		"api_key":"sk-second",
+		"tokens":{"input_tokens":10,"output_tokens":20}
+	}`))
+	if err != nil {
+		t.Fatalf("NormalizeRaw(second) error = %v", err)
+	}
+	if first.EventHash == second.EventHash {
+		t.Fatalf("event hashes collide across API keys: %q", first.EventHash)
+	}
+}
+
 func TestBuildPayloadIncludesUpstreamUsageMetadata(t *testing.T) {
 	payload := BuildPayload([]Event{{
 		Timestamp:         "2026-06-13T00:00:00Z",

--- a/cliproxyapi-pro-core/embeddedusage/server.go
+++ b/cliproxyapi-pro-core/embeddedusage/server.go
@@ -2,11 +2,14 @@ package embeddedusage
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +20,7 @@ import (
 
 const accountInspectionScheduleExportRecordType = "account_inspection_schedule"
 const accountInspectionSnapshotExportRecordType = "account_inspection_snapshot"
+const backupManifestRecordType = "backup_manifest"
 const usageHistoryStartCursorValue = int64(1<<63 - 1)
 
 type usageStreamEvent = internalusage.Payload
@@ -48,6 +52,14 @@ type accountInspectionSnapshotExportRecord struct {
 	Version    int             `json:"version"`
 	Snapshot   json.RawMessage `json:"snapshot"`
 	ExportedAt int64           `json:"exported_at_ms"`
+}
+
+type backupManifestRecord struct {
+	RecordType string `json:"record_type"`
+	Version    int    `json:"version"`
+	Records    int    `json:"records"`
+	SHA256     string `json:"sha256"`
+	ExportedAt int64  `json:"exported_at_ms"`
 }
 
 type Server struct {
@@ -654,7 +666,22 @@ func (s *Server) exportJSONL(ctx context.Context) ([]byte, error) {
 			data = append(data, '\n')
 		}
 	}
-	return data, nil
+	digest := sha256.Sum256(data)
+	manifest, err := json.Marshal(backupManifestRecord{
+		RecordType: backupManifestRecordType,
+		Version:    1,
+		Records:    bytes.Count(data, []byte{'\n'}),
+		SHA256:     fmt.Sprintf("%x", digest),
+		ExportedAt: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	output := make([]byte, 0, len(manifest)+1+len(data))
+	output = append(output, manifest...)
+	output = append(output, '\n')
+	output = append(output, data...)
+	return output, nil
 }
 
 func (s *Server) handleUsageExport(c *gin.Context) {
@@ -669,24 +696,19 @@ func (s *Server) handleUsageExport(c *gin.Context) {
 }
 
 func (s *Server) handleUsageImport(c *gin.Context) {
+	eventStage, err := os.CreateTemp("", "cliproxy-usage-import-*.jsonl")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	eventStagePath := eventStage.Name()
+	defer func() {
+		_ = eventStage.Close()
+		_ = os.Remove(eventStagePath)
+	}()
 	reader := bufio.NewScanner(c.Request.Body)
 	reader.Buffer(make([]byte, 64*1024), 64*1024*1024)
-	events := make([]internalusage.Event, 0, s.cfg.BatchSize)
-	result := InsertResult{}
 	totalEvents := 0
-	flushEvents := func() error {
-		if len(events) == 0 {
-			return nil
-		}
-		batchResult, err := s.store.InsertEvents(c.Request.Context(), events)
-		if err != nil {
-			return err
-		}
-		result.Inserted += batchResult.Inserted
-		result.Skipped += batchResult.Skipped
-		events = events[:0]
-		return nil
-	}
 	var modelPrices map[string]ModelPrice
 	var modelPriceRules []ModelPriceRule
 	modelPriceRecords := 0
@@ -703,6 +725,10 @@ func (s *Server) handleUsageImport(c *gin.Context) {
 	var monitoringSettings *MonitoringSettings
 	monitoringSettingsRecords := 0
 	failed := 0
+	var manifest *backupManifestRecord
+	hashedRecords := 0
+	hasher := sha256.New()
+	nonEmptyRecords := 0
 	for reader.Scan() {
 		line := strings.TrimSpace(reader.Text())
 		if line == "" {
@@ -711,8 +737,34 @@ func (s *Server) handleUsageImport(c *gin.Context) {
 		raw := []byte(line)
 		recordType, err := readImportRecordType(raw)
 		if err != nil {
+			nonEmptyRecords++
+			if manifest != nil {
+				_, _ = hasher.Write(raw)
+				_, _ = hasher.Write([]byte{'\n'})
+				hashedRecords++
+			}
 			failed++
 			continue
+		}
+		if recordType == backupManifestRecordType {
+			if nonEmptyRecords != 0 || manifest != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "backup manifest must be the first and only manifest record"})
+				return
+			}
+			parsed, err := parseBackupManifest(raw)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			manifest = &parsed
+			nonEmptyRecords++
+			continue
+		}
+		nonEmptyRecords++
+		if manifest != nil {
+			_, _ = hasher.Write(raw)
+			_, _ = hasher.Write([]byte{'\n'})
+			hashedRecords++
 		}
 		switch recordType {
 		case accountInspectionScheduleExportRecordType:
@@ -780,22 +832,76 @@ func (s *Server) handleUsageImport(c *gin.Context) {
 			authRuntimeStatsRecords++
 			continue
 		}
-		event, err := internalusage.NormalizeRaw(raw)
-		if err != nil {
+		if recordType != "" {
 			failed++
 			continue
 		}
-		events = append(events, event)
+		if _, err := internalusage.NormalizeRaw(raw); err != nil {
+			failed++
+			continue
+		}
+		if _, err := eventStage.Write(raw); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if _, err := eventStage.Write([]byte{'\n'}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		totalEvents++
-		if len(events) >= s.cfg.BatchSize {
+	}
+	if err := reader.Err(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if manifest != nil {
+		actualHash := fmt.Sprintf("%x", hasher.Sum(nil))
+		if failed > 0 || hashedRecords != manifest.Records || actualHash != manifest.SHA256 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "backup manifest verification failed"})
+			return
+		}
+	}
+	result := InsertResult{}
+	batchSize := s.cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	if _, err := eventStage.Seek(0, 0); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	events := make([]internalusage.Event, 0, batchSize)
+	flushEvents := func() error {
+		if len(events) == 0 {
+			return nil
+		}
+		batchResult, err := s.store.InsertEvents(c.Request.Context(), events)
+		if err != nil {
+			return err
+		}
+		result.Inserted += batchResult.Inserted
+		result.Skipped += batchResult.Skipped
+		events = events[:0]
+		return nil
+	}
+	stagedReader := bufio.NewScanner(eventStage)
+	stagedReader.Buffer(make([]byte, 64*1024), 64*1024*1024)
+	for stagedReader.Scan() {
+		event, err := internalusage.NormalizeRaw(stagedReader.Bytes())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		events = append(events, event)
+		if len(events) >= batchSize {
 			if err := flushEvents(); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
 		}
 	}
-	if err := reader.Err(); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	if err := stagedReader.Err(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	if err := flushEvents(); err != nil {
@@ -831,12 +937,7 @@ func (s *Server) handleUsageImport(c *gin.Context) {
 			return
 		}
 	}
-	importedRoutingCursors, err := s.store.ImportRoutingCursorStates(c.Request.Context(), routingCursors)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	importedAuthRuntimeStats, err := s.store.ImportAuthRuntimeStats(c.Request.Context(), authRuntimeStats)
+	importedRoutingCursors, importedAuthRuntimeStats, err := s.store.ImportRuntimeState(c.Request.Context(), routingCursors, authRuntimeStats)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -926,6 +1027,25 @@ func readImportRecordType(raw []byte) (string, error) {
 		return "", err
 	}
 	return header.RecordType, nil
+}
+
+func parseBackupManifest(raw []byte) (backupManifestRecord, error) {
+	var manifest backupManifestRecord
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return backupManifestRecord{}, err
+	}
+	if manifest.Version != 1 {
+		return backupManifestRecord{}, fmt.Errorf("unsupported backup manifest version %d", manifest.Version)
+	}
+	if manifest.Records < 0 || len(manifest.SHA256) != sha256.Size*2 {
+		return backupManifestRecord{}, fmt.Errorf("invalid backup manifest")
+	}
+	for _, character := range manifest.SHA256 {
+		if !strings.ContainsRune("0123456789abcdef", character) {
+			return backupManifestRecord{}, fmt.Errorf("invalid backup manifest hash")
+		}
+	}
+	return manifest, nil
 }
 
 func parseAccountInspectionScheduleImportRecord(raw []byte) (json.RawMessage, error) {

--- a/cliproxyapi-pro-core/embeddedusage/server_test.go
+++ b/cliproxyapi-pro-core/embeddedusage/server_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -15,6 +17,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/embeddedusage/internalusage"
 )
+
+type failingImportReader struct{}
+
+func (failingImportReader) Read([]byte) (int, error) {
+	return 0, errors.New("forced import read failure")
+}
 
 func TestUsageStreamPushesInsertedEventsWithoutPollingDelay(t *testing.T) {
 	store := openTestStore(t)
@@ -94,6 +102,77 @@ func TestHandleUsageResetRequiresConfirmation(t *testing.T) {
 	router.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestUsageImportDoesNotWriteBeforeRequestIsFullyRead(t *testing.T) {
+	store := openTestStore(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	server := NewServer(Config{QueryLimit: 50000, BatchSize: 1}, store)
+	server.RegisterGinRoutes(router.Group("/usage"))
+	event, err := json.Marshal(testUsageEvent(0, false, 10))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	body := io.MultiReader(bytes.NewReader(append(event, '\n')), failingImportReader{})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/usage/import", body)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	events, _, err := store.Counts(context.Background())
+	if err != nil || events != 0 {
+		t.Fatalf("Counts() = %d, _, %v; import must not partially write", events, err)
+	}
+}
+
+func TestUsageImportDoesNotTreatUnknownRecordAsEvent(t *testing.T) {
+	store := openTestStore(t)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/usage/import", strings.NewReader(`{"record_type":"future_record","model":"must-not-import"}`))
+	testUsageRouter(store).ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 legacy-compatible response; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var result struct {
+		Failed int `json:"failed"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil || result.Failed != 1 {
+		t.Fatalf("import result = %+v, %v; want one failed record", result, err)
+	}
+	events, _, err := store.Counts(context.Background())
+	if err != nil || events != 0 {
+		t.Fatalf("Counts() = %d, _, %v; unknown record must not become an event", events, err)
+	}
+}
+
+func TestUsageImportRejectsTamperedManifestBackupBeforeWriting(t *testing.T) {
+	sourceStore := openTestStore(t)
+	insertTestUsageEvents(t, sourceStore, testUsageEvent(0, false, 10))
+	exportRecorder := httptest.NewRecorder()
+	testUsageRouter(sourceStore).ServeHTTP(exportRecorder, httptest.NewRequest(http.MethodGet, "/usage/export", nil))
+	if exportRecorder.Code != http.StatusOK {
+		t.Fatalf("export status = %d; body=%s", exportRecorder.Code, exportRecorder.Body.String())
+	}
+	if !bytes.HasPrefix(exportRecorder.Body.Bytes(), []byte(`{"record_type":"backup_manifest"`)) {
+		t.Fatalf("export is missing backup manifest: %s", exportRecorder.Body.String())
+	}
+	tampered := bytes.Replace(exportRecorder.Body.Bytes(), []byte(`"model":"model"`), []byte(`"model":"tampered"`), 1)
+	if bytes.Equal(tampered, exportRecorder.Body.Bytes()) {
+		t.Fatal("test backup event was not changed")
+	}
+
+	targetStore := openTestStore(t)
+	importRecorder := httptest.NewRecorder()
+	testUsageRouter(targetStore).ServeHTTP(importRecorder, httptest.NewRequest(http.MethodPost, "/usage/import", bytes.NewReader(tampered)))
+	if importRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("import status = %d, want 400; body=%s", importRecorder.Code, importRecorder.Body.String())
+	}
+	events, _, err := targetStore.Counts(context.Background())
+	if err != nil || events != 0 {
+		t.Fatalf("Counts() = %d, _, %v; tampered backup must not write", events, err)
 	}
 }
 

--- a/cliproxyapi-pro-core/embeddedusage/service.go
+++ b/cliproxyapi-pro-core/embeddedusage/service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/embeddedusage/internalusage"
@@ -16,10 +17,11 @@ import (
 )
 
 type Service struct {
-	ctx    context.Context
-	cfg    Config
-	store  *Store
-	server *Server
+	ctx     context.Context
+	cfg     Config
+	store   *Store
+	server  *Server
+	workers sync.WaitGroup
 }
 
 func Start(ctx context.Context) (*Service, error) {
@@ -43,12 +45,13 @@ func Start(ctx context.Context) (*Service, error) {
 		store: store,
 	}
 	service.server = NewServer(cfg, store)
-	go service.collect(ctx)
-	go service.maintain(ctx)
-	go service.runWebDAVBackups(ctx)
-	go service.runModelPriceSync(ctx)
+	service.startWorker(func() { service.collect(ctx) })
+	service.startWorker(func() { service.maintain(ctx) })
+	service.startWorker(func() { service.runWebDAVBackups(ctx) })
+	service.startWorker(func() { service.runModelPriceSync(ctx) })
 	go func() {
 		<-ctx.Done()
+		service.workers.Wait()
 		stopRuntimeStateWriter(service)
 		if err := store.Close(); err != nil {
 			log.WithError(err).Warn("failed to close embedded usage store")
@@ -57,6 +60,14 @@ func Start(ctx context.Context) (*Service, error) {
 
 	log.Infof("embedded usage service started with db %s", cfg.DBPath)
 	return service, nil
+}
+
+func (s *Service) startWorker(run func()) {
+	s.workers.Add(1)
+	go func() {
+		defer s.workers.Done()
+		run()
+	}()
 }
 
 func (s *Service) runModelPriceSync(ctx context.Context) {
@@ -99,6 +110,17 @@ func (s *Service) Server() *Server {
 func (s *Service) collect(ctx context.Context) {
 	ticker := time.NewTicker(s.cfg.PollInterval)
 	defer ticker.Stop()
+	pending := make([]internalusage.Event, 0, s.cfg.BatchSize)
+	defer func() {
+		if len(pending) == 0 {
+			return
+		}
+		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := s.store.InsertLiveEvents(flushCtx, pending); err != nil {
+			log.WithError(err).Warn("failed to flush pending embedded usage events during shutdown")
+		}
+	}()
 
 	for {
 		select {
@@ -107,8 +129,32 @@ func (s *Service) collect(ctx context.Context) {
 		default:
 		}
 
-		items := redisqueue.PopOldest(s.cfg.BatchSize)
-		if len(items) == 0 {
+		if len(pending) == 0 {
+			items := redisqueue.PopOldest(s.cfg.BatchSize)
+			if len(items) == 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					continue
+				}
+			}
+			for _, item := range items {
+				event, err := internalusage.NormalizeRaw(item)
+				if err != nil {
+					if addErr := s.store.AddDeadLetter(ctx, string(item), err); addErr != nil {
+						log.WithError(addErr).Warn("failed to add embedded usage dead letter")
+					}
+					continue
+				}
+				pending = append(pending, event)
+			}
+		}
+		if len(pending) == 0 {
+			continue
+		}
+		if _, err := s.store.InsertLiveEvents(ctx, pending); err != nil {
+			log.WithError(err).Warn("failed to insert embedded usage events")
 			select {
 			case <-ctx.Done():
 				return
@@ -116,21 +162,7 @@ func (s *Service) collect(ctx context.Context) {
 				continue
 			}
 		}
-
-		events := make([]internalusage.Event, 0, len(items))
-		for _, item := range items {
-			event, err := internalusage.NormalizeRaw(item)
-			if err != nil {
-				if addErr := s.store.AddDeadLetter(ctx, string(item), err); addErr != nil {
-					log.WithError(addErr).Warn("failed to add embedded usage dead letter")
-				}
-				continue
-			}
-			events = append(events, event)
-		}
-		if _, err := s.store.InsertEvents(ctx, events); err != nil {
-			log.WithError(err).Warn("failed to insert embedded usage events")
-		}
+		pending = pending[:0]
 	}
 }
 

--- a/cliproxyapi-pro-core/embeddedusage/service_test.go
+++ b/cliproxyapi-pro-core/embeddedusage/service_test.go
@@ -1,0 +1,53 @@
+package embeddedusage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
+)
+
+func TestCollectorRetriesPoppedBatchAfterSQLiteFailure(t *testing.T) {
+	store := openTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	redisqueue.SetEnabled(false)
+	redisqueue.SetEnabled(true)
+	redisqueue.SetUsageStatisticsEnabled(true)
+	t.Cleanup(func() { redisqueue.SetEnabled(false) })
+	if _, err := store.db.ExecContext(ctx, `create trigger fail_usage_insert before insert on usage_events begin select raise(abort, 'forced usage write failure'); end`); err != nil {
+		t.Fatalf("create trigger error = %v", err)
+	}
+	payload, err := json.Marshal(testUsageEvent(0, false, 10))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	redisqueue.Enqueue(payload)
+	service := &Service{ctx: ctx, cfg: Config{BatchSize: 10, PollInterval: 5 * time.Millisecond}, store: store}
+	done := make(chan struct{})
+	go func() {
+		service.collect(ctx)
+		close(done)
+	}()
+
+	// Allow several failed persistence attempts so the item has definitely left the upstream queue.
+	time.Sleep(75 * time.Millisecond)
+	if _, err := store.db.ExecContext(ctx, `drop trigger fail_usage_insert`); err != nil {
+		t.Fatalf("drop trigger error = %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events, _, countErr := store.Counts(ctx)
+		if countErr == nil && events == 1 {
+			cancel()
+			<-done
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	t.Fatal("collector did not retry the popped batch after SQLite recovered")
+}

--- a/cliproxyapi-pro-core/embeddedusage/store.go
+++ b/cliproxyapi-pro-core/embeddedusage/store.go
@@ -229,6 +229,7 @@ const authRuntimeStatsExportRecordType = "auth_runtime_stats"
 type Store struct {
 	db           *sql.DB
 	quotaCacheMu sync.Mutex
+	usageWriteMu sync.Mutex
 	summaryMu    sync.RWMutex
 	summaryCache *cachedUsageSummary
 	eventMu      sync.Mutex
@@ -481,6 +482,36 @@ func (s *Store) init() error {
 }
 
 func (s *Store) InsertEvents(ctx context.Context, events []internalusage.Event) (InsertResult, error) {
+	s.usageWriteMu.Lock()
+	defer s.usageWriteMu.Unlock()
+	return s.insertEvents(ctx, events)
+}
+
+func (s *Store) InsertLiveEvents(ctx context.Context, events []internalusage.Event) (InsertResult, error) {
+	s.usageWriteMu.Lock()
+	defer s.usageWriteMu.Unlock()
+	if len(events) == 0 {
+		return InsertResult{}, nil
+	}
+	snapshot, err := s.readUsageSummarySnapshot(ctx)
+	if err != nil {
+		return InsertResult{}, err
+	}
+	filtered := make([]internalusage.Event, 0, len(events))
+	skipped := 0
+	for _, event := range events {
+		if snapshot.State.ResetAtMS > 0 && event.TimestampMS <= snapshot.State.ResetAtMS {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	result, err := s.insertEvents(ctx, filtered)
+	result.Skipped += skipped
+	return result, err
+}
+
+func (s *Store) insertEvents(ctx context.Context, events []internalusage.Event) (InsertResult, error) {
 	if len(events) == 0 {
 		return InsertResult{}, nil
 	}
@@ -1451,6 +1482,8 @@ func (s *Store) DeleteEventsBefore(ctx context.Context, beforeMs int64) (int64, 
 	if beforeMs <= 0 {
 		return 0, nil
 	}
+	s.usageWriteMu.Lock()
+	defer s.usageWriteMu.Unlock()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
@@ -1512,6 +1545,8 @@ func (s *Store) DeleteEventsBefore(ctx context.Context, beforeMs int64) (int64, 
 }
 
 func (s *Store) ResetUsageStatistics(ctx context.Context) (UsageResetResult, error) {
+	s.usageWriteMu.Lock()
+	defer s.usageWriteMu.Unlock()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return UsageResetResult{}, err
@@ -1879,16 +1914,21 @@ func (s *Store) SetRoutingCursorState(ctx context.Context, state RoutingCursorSt
 }
 
 func (s *Store) ImportRoutingCursorStates(ctx context.Context, items []RoutingCursorState) (int, error) {
-	if len(items) == 0 {
-		return 0, nil
+	imported, _, err := s.ImportRuntimeState(ctx, items, nil)
+	return imported, err
+}
+
+func (s *Store) ImportRuntimeState(ctx context.Context, cursors []RoutingCursorState, stats []AuthRuntimeStats) (int, int, error) {
+	if len(cursors) == 0 && len(stats) == 0 {
+		return 0, 0, nil
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	imported := 0
-	for _, item := range items {
+	importedCursors := 0
+	for _, item := range cursors {
 		item.CursorKey = strings.TrimSpace(item.CursorKey)
 		item.LastAuthID = strings.TrimSpace(item.LastAuthID)
 		if item.CursorKey == "" || item.LastAuthID == "" {
@@ -1901,18 +1941,36 @@ func (s *Store) ImportRoutingCursorStates(ctx context.Context, items []RoutingCu
 			on conflict(cursor_key) do update set last_auth_id = excluded.last_auth_id, updated_at_ms = excluded.updated_at_ms`,
 			item.CursorKey, item.LastAuthID, item.UpdatedAtMS)
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 		if affected, _ := result.RowsAffected(); affected > 0 {
-			imported++
+			importedCursors++
 		}
 	}
-	if imported > 0 {
+	if importedCursors > 0 {
 		if err := bumpRuntimeGenerationTx(ctx, tx, "routing_cursor_state", time.Now().UnixMilli()); err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 	}
-	return imported, tx.Commit()
+	importedStats := 0
+	for _, item := range stats {
+		changed, err := setAuthRuntimeStatsTx(ctx, tx, item, true)
+		if err != nil {
+			return 0, 0, err
+		}
+		if changed {
+			importedStats++
+		}
+	}
+	if importedStats > 0 {
+		if err := bumpRuntimeGenerationTx(ctx, tx, "auth_runtime_stats", time.Now().UnixMilli()); err != nil {
+			return 0, 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, 0, err
+	}
+	return importedCursors, importedStats, nil
 }
 
 func (s *Store) GetAuthRuntimeStats(ctx context.Context, authIndex, authID string) (AuthRuntimeStats, bool, error) {
@@ -2038,27 +2096,8 @@ func (s *Store) SetAuthRuntimeStats(ctx context.Context, item AuthRuntimeStats) 
 }
 
 func (s *Store) ImportAuthRuntimeStats(ctx context.Context, items []AuthRuntimeStats) (int, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	imported := 0
-	for _, item := range items {
-		changed, err := setAuthRuntimeStatsTx(ctx, tx, item, true)
-		if err != nil {
-			return 0, err
-		}
-		if changed {
-			imported++
-		}
-	}
-	if imported > 0 {
-		if err := bumpRuntimeGenerationTx(ctx, tx, "auth_runtime_stats", time.Now().UnixMilli()); err != nil {
-			return 0, err
-		}
-	}
-	return imported, tx.Commit()
+	_, imported, err := s.ImportRuntimeState(ctx, nil, items)
+	return imported, err
 }
 
 func (s *Store) DeleteAuthRuntimeState(ctx context.Context, authID, authIndex, fileName string) error {

--- a/cliproxyapi-pro-core/embeddedusage/store_test.go
+++ b/cliproxyapi-pro-core/embeddedusage/store_test.go
@@ -401,6 +401,40 @@ func TestResetUsageStatisticsOnEmptyStoreIsNoop(t *testing.T) {
 	}
 }
 
+func TestInsertLiveEventsRejectsEventsFromBeforeReset(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	insertTestUsageEvents(t, store, testUsageEvent(0, false, 10))
+	reset, err := store.ResetUsageStatistics(ctx)
+	if err != nil {
+		t.Fatalf("ResetUsageStatistics() error = %v", err)
+	}
+
+	stale := testUsageEvent(1, false, 20)
+	result, err := store.InsertLiveEvents(ctx, []internalusage.Event{stale})
+	if err != nil {
+		t.Fatalf("InsertLiveEvents(stale) error = %v", err)
+	}
+	if result.Inserted != 0 || result.Skipped != 1 {
+		t.Fatalf("InsertLiveEvents(stale) = %+v, want skipped", result)
+	}
+
+	fresh := testUsageEvent(2, false, 30)
+	fresh.TimestampMS = reset.ResetAtMS + 1
+	fresh.Timestamp = time.UnixMilli(fresh.TimestampMS).UTC().Format(time.RFC3339Nano)
+	result, err = store.InsertLiveEvents(ctx, []internalusage.Event{fresh})
+	if err != nil {
+		t.Fatalf("InsertLiveEvents(fresh) error = %v", err)
+	}
+	if result.Inserted != 1 || result.Skipped != 0 {
+		t.Fatalf("InsertLiveEvents(fresh) = %+v, want inserted", result)
+	}
+	events, _, err := store.Counts(ctx)
+	if err != nil || events != 1 {
+		t.Fatalf("Counts() = %d, _, %v; want one fresh event", events, err)
+	}
+}
+
 func TestOpenStoreRebuildsStaleUsageSummary(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "usage.sqlite")
 	ctx := context.Background()
@@ -699,6 +733,121 @@ func TestQueuedAuthRuntimeDeleteCannotBeOverwrittenByPendingSnapshot(t *testing.
 	}
 }
 
+func TestRuntimeStateWriterRetainsSnapshotsAfterWriteFailure(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `create trigger fail_auth_runtime_insert before insert on auth_runtime_stats begin select raise(abort, 'forced runtime write failure'); end`); err != nil {
+		t.Fatalf("create trigger error = %v", err)
+	}
+	service := &Service{ctx: ctx, store: store}
+	SetDefaultService(service)
+	defer stopRuntimeStateWriter(service)
+
+	QueueAuthRuntimeStats(AuthRuntimeStats{
+		AuthIndex: "idx-retry", AuthID: "auth-retry", SelectedCount: 7, UpdatedAtMS: 100,
+	})
+	if err := flushRuntimeStateWrites(ctx, store); err == nil {
+		t.Fatal("flushRuntimeStateWrites() error = nil, want forced write failure")
+	}
+	if _, err := store.db.ExecContext(ctx, `drop trigger fail_auth_runtime_insert`); err != nil {
+		t.Fatalf("drop trigger error = %v", err)
+	}
+	if err := flushRuntimeStateWrites(ctx, store); err != nil {
+		t.Fatalf("flushRuntimeStateWrites() retry error = %v", err)
+	}
+	stats, ok, err := store.GetAuthRuntimeStats(ctx, "idx-retry", "auth-retry")
+	if err != nil || !ok || stats.SelectedCount != 7 {
+		t.Fatalf("GetAuthRuntimeStats() after retry = %+v, %v, %v", stats, ok, err)
+	}
+}
+
+func TestRuntimeStateWriterCoalescesOverflowWithoutLosingLatestSnapshot(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	heldTx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	service := &Service{ctx: ctx, store: store}
+	SetDefaultService(service)
+	defer stopRuntimeStateWriter(service)
+	QueueAuthRuntimeStats(AuthRuntimeStats{
+		AuthIndex: "idx-overflow", AuthID: "auth-overflow", SelectedCount: 1, UpdatedAtMS: 1,
+	})
+	time.Sleep(300 * time.Millisecond)
+	for index := 2; index <= 2200; index++ {
+		QueueAuthRuntimeStats(AuthRuntimeStats{
+			AuthIndex: "idx-overflow", AuthID: "auth-overflow", SelectedCount: int64(index), UpdatedAtMS: int64(index),
+		})
+	}
+	if err := heldTx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if err := flushRuntimeStateWrites(ctx, store); err != nil {
+		t.Fatalf("flushRuntimeStateWrites() error = %v", err)
+	}
+	stats, ok, err := store.GetAuthRuntimeStats(ctx, "idx-overflow", "auth-overflow")
+	if err != nil || !ok || stats.SelectedCount != 2200 {
+		t.Fatalf("GetAuthRuntimeStats() = %+v, %v, %v; want latest overflow snapshot", stats, ok, err)
+	}
+}
+
+func TestRuntimeStateWriterRemainsAvailableUntilExplicitStop(t *testing.T) {
+	store := openTestStore(t)
+	serviceCtx, cancelService := context.WithCancel(context.Background())
+	service := &Service{ctx: serviceCtx, store: store}
+	SetDefaultService(service)
+	defer stopRuntimeStateWriter(service)
+	cancelService()
+	time.Sleep(25 * time.Millisecond)
+
+	QueueAuthRuntimeStats(AuthRuntimeStats{
+		AuthIndex: "idx-shutdown", AuthID: "auth-shutdown", SelectedCount: 9, UpdatedAtMS: 900,
+	})
+	flushCtx, cancelFlush := context.WithTimeout(context.Background(), time.Second)
+	defer cancelFlush()
+	if err := flushRuntimeStateWrites(flushCtx, store); err != nil {
+		t.Fatalf("flushRuntimeStateWrites() after service cancellation error = %v", err)
+	}
+	stats, ok, err := store.GetAuthRuntimeStats(context.Background(), "idx-shutdown", "auth-shutdown")
+	if err != nil || !ok || stats.SelectedCount != 9 {
+		t.Fatalf("GetAuthRuntimeStats() = %+v, %v, %v; writer stopped before explicit shutdown", stats, ok, err)
+	}
+}
+
+func TestFailedRuntimeStateDeleteDoesNotSuppressLaterSnapshot(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	if err := store.SetAuthRuntimeStats(ctx, AuthRuntimeStats{
+		AuthIndex: "idx-delete-failure", AuthID: "auth-delete-failure", SelectedCount: 1, UpdatedAtMS: 100,
+	}); err != nil {
+		t.Fatalf("SetAuthRuntimeStats() error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `create trigger fail_auth_runtime_delete before delete on auth_runtime_stats begin select raise(abort, 'forced runtime delete failure'); end`); err != nil {
+		t.Fatalf("create trigger error = %v", err)
+	}
+	service := &Service{ctx: ctx, store: store}
+	SetDefaultService(service)
+	defer stopRuntimeStateWriter(service)
+
+	if err := DeleteAuthRuntimeState(ctx, "auth-delete-failure", "idx-delete-failure", ""); err == nil {
+		t.Fatal("DeleteAuthRuntimeState() error = nil, want forced delete failure")
+	}
+	if _, err := store.db.ExecContext(ctx, `drop trigger fail_auth_runtime_delete`); err != nil {
+		t.Fatalf("drop trigger error = %v", err)
+	}
+	QueueAuthRuntimeStats(AuthRuntimeStats{
+		AuthIndex: "idx-delete-failure", AuthID: "auth-delete-failure", SelectedCount: 9, UpdatedAtMS: 200,
+	})
+	if err := flushRuntimeStateWrites(ctx, store); err != nil {
+		t.Fatalf("flushRuntimeStateWrites() error = %v", err)
+	}
+	stats, ok, err := store.GetAuthRuntimeStats(ctx, "idx-delete-failure", "auth-delete-failure")
+	if err != nil || !ok || stats.SelectedCount != 9 {
+		t.Fatalf("GetAuthRuntimeStats() = %+v, %v, %v; want later snapshot", stats, ok, err)
+	}
+}
+
 func TestServerExportFlushesQueuedRuntimeState(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
@@ -753,5 +902,23 @@ func TestRuntimeStateImportUsesExplicitRestoreSemantics(t *testing.T) {
 	stats, ok, err := store.GetAuthRuntimeStats(ctx, "idx-a", "auth-a")
 	if err != nil || !ok || stats.SelectedCount != 9 || stats.SuccessCount != 7 || stats.FailureCount != 2 {
 		t.Fatalf("restored stats = %+v, %v, %v", stats, ok, err)
+	}
+}
+
+func TestRuntimeStateImportRollsBackCursorWhenStatsFail(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `create trigger fail_auth_runtime_import before insert on auth_runtime_stats begin select raise(abort, 'forced runtime import failure'); end`); err != nil {
+		t.Fatalf("create trigger error = %v", err)
+	}
+	_, _, err := store.ImportRuntimeState(ctx,
+		[]RoutingCursorState{{CursorKey: "single|codex|gpt-5|0|all", LastAuthID: "backup-auth", UpdatedAtMS: 100}},
+		[]AuthRuntimeStats{{AuthIndex: "idx-import", AuthID: "auth-import", SelectedCount: 2, UpdatedAtMS: 100}},
+	)
+	if err == nil {
+		t.Fatal("ImportRuntimeState() error = nil, want forced stats failure")
+	}
+	if _, ok, err := store.GetRoutingCursorState(ctx, "single|codex|gpt-5|0|all"); err != nil || ok {
+		t.Fatalf("GetRoutingCursorState() after rollback = _, %v, %v; want missing", ok, err)
 	}
 }

--- a/docs/code-review/2026-07.md
+++ b/docs/code-review/2026-07.md
@@ -14,7 +14,7 @@ The pinned PR baseline lives in `compatibility/upstream.env`. Pull requests and 
 | --- | --- | --- |
 | 1 | Validation scripts, PR CI, release gates, review register | Completed |
 | 2 | Patch generators and release supply chain | Completed |
-| 3 | SQLite, import/export, reset, cursor, and runtime state | Pending |
+| 3 | SQLite, import/export, reset, cursor, and runtime state | Completed |
 | 4 | Account inspection, routing protection, and plugin boundaries | Pending |
 | 5 | Frontend API contracts, realtime state, and maintainability | Pending |
 
@@ -42,6 +42,25 @@ The pinned PR baseline lives in `compatibility/upstream.env`. Pull requests and 
 | RELEASE-001 | P1 | GitHub Actions | Workflow actions used mutable major-version tags, including actions with release and workflow-run permissions | A moved tag could execute unreviewed code with repository or registry credentials | Inspect every external `uses:` reference | Pin all actions to commit SHAs and enable grouped Dependabot updates | Workflow pin checker and actionlint | Resolved |
 | RELEASE-002 | P1 | Release inputs | Matrix jobs resolved upstream tags and the models branch independently | One release could combine different source or model commits across platforms | Compare the checkout and models fetch inputs used by matrix jobs | Resolve Core, Management, and models commits once and pass immutable SHAs to every consumer | Workflow validation and release notes mapping | Resolved |
 | RELEASE-003 | P1 | Build dependencies | Container bases, Komari executable image, manylinux builders, and downloaded Go archives were not content-verified | Rebuilding the same commit could execute different build or runtime inputs | Inspect Docker `FROM`/`COPY --from` and toolchain download steps | Pin image digests and verify the official Go archive SHA-256 | Source-image build and workflow validation | Resolved |
+| STATE-001 | P1 | Runtime state queue | Failed SQLite writes were removed from the writer's pending maps, and snapshots were silently dropped when the channel filled | Routing cursors or account runtime statistics could lag permanently or disappear across export/restart | Force an auth-runtime insert failure or hold SQLite while queuing more than 1024 snapshots | Retain failed items, coalesce overflow by key, drain overflow before flush/delete/stop, and retry during shutdown | Runtime writer failure and overflow tests | Resolved |
+| STATE-002 | P1 | Usage collection lifecycle | `PopOldest` removed usage payloads before SQLite commit, and service shutdown closed the store without waiting for workers | A transient write error or graceful restart could lose an already-popped batch or race an in-flight store operation | Fail `usage_events` inserts after enqueue, then recover SQLite; cancel the service during background work | Keep the popped batch pending until commit, retry it, flush pending events on shutdown, and wait for workers before closing SQLite | Collector retry test and race detector | Resolved |
+| STATE-003 | P1 | Reset boundary | A delayed live batch could commit after reset and repopulate statistics with pre-reset requests | Reset appeared to succeed, then old requests reappeared and stale SSE cursors advanced | Reset after an event is queued or popped but before its insert transaction | Serialize live inserts with reset/retention and reject live events whose timestamps are at or before the persisted reset boundary | Live-event reset-boundary test and SSE reset tests | Resolved |
+| STATE-004 | P1 | Backup integrity | JSONL had no file-level integrity record, and event batches could be written before the request body was fully read | Truncated, unreadable, or modified backups could leave a partial restore while the request failed or reported skipped records | Fail the reader after the first batch or alter a valid exported event line | Add a first-line record-count/SHA-256 manifest and complete scanning plus verification before database writes; retain legacy import compatibility | Read-failure and tampered-manifest tests | Resolved |
+| STATE-005 | P1 | Runtime restore transaction | Routing cursors and auth runtime statistics were restored in separate transactions | A stats failure could leave restored cursor ordering paired with old selection counters | Force the auth-runtime insert after the cursor import succeeds | Restore both runtime record types in one SQLite transaction, then apply the committed snapshot to the live manager | Runtime import rollback and live restore tests | Resolved |
+| STATE-006 | P2 | Event deduplication | Generated `event_hash` values omitted `api_key_hash` | Otherwise identical hashless events from different client API keys could collide and lose attribution | Normalize matching payloads that differ only by API key | Include the hashed API-key identity in newly generated event hashes while preserving hashes from older exports | Internal usage hash test | Resolved |
+
+## Package 3 Residual Risks
+
+- New exports have a file-level SHA-256 manifest, while legacy manifest-free backups remain accepted for compatibility and cannot be verified against truncation or modification.
+- Database-backed records and account-inspection files are restored through idempotent stages because SQLite cannot share a transaction with external file callbacks. Retrying a failed import is safe for usage hashes and versioned runtime records, but the entire mixed restore is not one cross-resource transaction.
+- Export flushes queued runtime state first, but its independent SQLite reads can observe adjacent commits rather than one database-wide snapshot. The manifest proves file integrity, not that every record type came from the exact same instant.
+- Usage payloads still originate in an in-process upstream queue. Transient SQLite failures and graceful shutdown are covered, but an abrupt process or host crash before persistence can still lose that in-memory window.
+
+## Package 3 Validation Results
+
+- Repository validation: 18 Python tests, immutable workflow action checks, syntax, JSON, YAML, and whitespace checks passed; ShellCheck and actionlint run in CI when available.
+- Core `v7.2.94`: embedded usage and internal normalization tests, management handlers, plugin host/store, Redis queue, auth scheduler tests, server build, and the embedded usage race detector passed on a fresh generated checkout.
+- Regression coverage includes queued-write failure/retry, queue overflow coalescing, explicit shutdown flushing, reset/live-insert ordering, import read failure, manifest tamper rejection, runtime-state transaction rollback, and API-key-aware event hashing.
 
 ## Package 2 Residual Risks
 


### PR DESCRIPTION
## Summary

- retain and coalesce queued runtime state across SQLite failures, saturation, service replacement, export, and shutdown
- retry popped usage batches, wait for background workers before closing SQLite, and keep reset as a hard boundary for delayed live events
- add first-line record-count and SHA-256 manifests to new JSONL backups while preserving legacy import compatibility
- stage imports to a private temporary file, verify the complete request before database writes, and reject unknown metadata records
- restore routing cursors and auth runtime statistics in one SQLite transaction
- include API-key identity in newly generated event hashes while preserving hashes from prior exports
- update the Package 3 review register and backup documentation

## Findings resolved

- STATE-001 runtime state queue loss on write failure or channel saturation
- STATE-002 usage batch loss and SQLite close lifecycle races
- STATE-003 pre-reset live events reappearing after reset
- STATE-004 backup truncation, tampering, and partial-read writes
- STATE-005 split runtime restore transactions
- STATE-006 API-key event-hash collisions

## Validation

- bash scripts/validation/repo.sh
- fresh upstream Core v7.2.94 generator preflight and rejected reapplication
- go test for embeddedusage, management handlers, pluginhost, pluginstore, redisqueue, and sdk auth
- go build of cmd/server
- go test -race for internal/embeddedusage/...

## Residual P2 boundaries

- legacy manifest-free backups cannot receive file-level integrity verification
- SQLite records and external account-inspection files cannot share one cross-resource transaction
- export integrity does not imply a single database-wide temporal snapshot
- abrupt process or host failure can still lose usage payloads that have not left the upstream in-memory queue
