### PR TITLE
fix(release): resolve Go checksums from metadata

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -536,6 +536,16 @@ jobs:
           rm -rf "dist/linux-${GOARCH}"
           mkdir -p "${archive_dir}"
 
+          go_archive="go${GO_VERSION}.linux-${GOARCH}.tar.gz"
+          go_sha256="$(
+            curl -fsSL 'https://go.dev/dl/?mode=json&include=all' |
+              python3 -c 'import json, sys; filename = sys.argv[1]; print(next(item["sha256"] for release in json.load(sys.stdin) for item in release["files"] if item["filename"] == filename))' "${go_archive}"
+          )"
+          if [[ ! "${go_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'Invalid SHA256 for %s: %s\n' "${go_archive}" "${go_sha256}" >&2
+            exit 1
+          fi
+
           docker run --rm \
             -v "${PWD}:/src" \
             -w /src \
@@ -544,12 +554,12 @@ jobs:
             -e RELEASE_TAG \
             -e CORE_TAG \
             -e BUILD_DATE \
+            -e "GO_SHA256=${go_sha256}" \
             "${MANYLINUX_IMAGE}" \
             bash -euo pipefail -c '
               go_archive="go${GO_VERSION}.linux-${GOARCH}.tar.gz"
               curl -fsSL "https://go.dev/dl/${go_archive}" -o "/tmp/${go_archive}"
-              curl -fsSL "https://go.dev/dl/${go_archive}.sha256" -o "/tmp/${go_archive}.sha256"
-              printf "%s  %s\n" "$(cat "/tmp/${go_archive}.sha256")" "/tmp/${go_archive}" | sha256sum -c -
+              printf "%s  %s\n" "${GO_SHA256}" "/tmp/${go_archive}" | sha256sum -c -
               rm -rf /usr/local/go
               tar -C /usr/local -xzf "/tmp/${go_archive}"
               export PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
## Summary

- resolve Linux Go archive checksums from the official Go download metadata API
- validate the resolved digest before passing it into the pinned manylinux container
- keep archive verification before extraction without maintaining per-version checksums

## Root cause

The release workflow treated `https://go.dev/dl/<archive>.sha256` as a checksum asset. That endpoint returns an HTTP 200 HTML redirect page, so both Linux glibc plugin builds failed in `sha256sum` during run 29936326151.

## Validation

- resolved valid Go 1.26.0 amd64 and arm64 SHA256 values from official metadata
- 19 Management customization/security tests passed
- 2 reproducible archive tests passed
- JSON, syntax, action pin and whitespace validation passed
- local Docker smoke test unavailable because the OrbStack socket is not accessible; required PR CI remains the remote gate