### PR TITLE
fix(release): pass FreeBSD build flags safely

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -608,13 +608,15 @@ jobs:
       - name: Build FreeBSD plugin-capable binary
         if: matrix.kind == 'freebsd-plugin'
         uses: go-cross/cgo-actions@d0b8f2f2d67923ce9a42d92a7ef0ed1ebd905f0a # v1
+        env:
+          GOFLAGS: -buildvcs=false -trimpath
         with:
           dir: upstream-core
           packages: ./cmd/server/
           targets: ${{ matrix.goos }}-${{ matrix.goarch }}
           out-dir: upstream-core/dist/${{ matrix.target }}/bin
           output: cli-proxy-api
-          flags: -buildvcs=false -trimpath -ldflags=-s -w
+          flags: -ldflags=-s -w
           x-flags: |
             main.Version=${{ needs.check-version.outputs.release_tag }}
             main.Commit=release-${{ needs.check-version.outputs.core_tag }}


### PR DESCRIPTION
## Summary

- pass reproducibility flags through Go's supported `GOFLAGS` environment variable
- keep the go-cross action `flags` input limited to the single linker flag it can pass safely
- preserve existing version, commit and build-date injection through `x-flags`

## Root cause

`go-cross/cgo-actions` interpolates its entire `flags` input as one process argument. The combined `-buildvcs=false -trimpath -ldflags=-s -w` string therefore became the value of `-buildvcs`, and Go 1.26 rejected it. This independently blocked the FreeBSD plugin matrix in release runs 29936326151 and 29937963776.

## Validation

- actual Core server build passed with `GOFLAGS=-buildvcs=false -trimpath` and a single `-ldflags=-s -w` argument
- 19 Management customization/security tests passed
- 2 reproducible archive tests passed
- repository syntax, JSON, action pin and whitespace checks passed