### PR TITLE
fix(vertex): bind tool images to function responses

### DIFF
--- a/cliproxyapi-pro-core/patches/apply_upstream_patches.py
+++ b/cliproxyapi-pro-core/patches/apply_upstream_patches.py
@@ -5565,6 +5565,119 @@ replace_once(
     's.persistMixedCursor(persistedCursorKey, picked.ID)',
 )
 
+# Vertex requires multimodal tool results to live inside the corresponding
+# functionResponse. Top-level sibling inline_data parts make the request end in
+# an invalid model turn and are rejected with HTTP 400.
+gemini_responses_request = ROOT / 'internal/translator/gemini/openai/responses/gemini_openai-responses_request.go'
+replace_once(
+    gemini_responses_request,
+    '''\tparts := make([][]byte, 0, 1+len(imageParts))
+\tparts = append(parts, functionResponse)
+\tparts = append(parts, imageParts...)
+\treturn parts
+''',
+    '''\tfor _, imagePart := range imageParts {
+\t\tinlineData := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+\t\tinlineData, _ = sjson.SetBytes(inlineData, "inlineData.mimeType", gjson.GetBytes(imagePart, "inline_data.mime_type").String())
+\t\tinlineData, _ = sjson.SetBytes(inlineData, "inlineData.data", gjson.GetBytes(imagePart, "inline_data.data").String())
+\t\tfunctionResponse, _ = sjson.SetRawBytes(functionResponse, "functionResponse.parts.-1", inlineData)
+\t}
+\treturn [][]byte{functionResponse}
+''',
+    'functionResponse.parts.-1',
+)
+
+gemini_responses_request_test = ROOT / 'internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go'
+replace_once(
+    gemini_responses_request_test,
+    '''\tparts := userContent.Get("parts").Array()
+\tif len(parts) < 2 {
+\t\tt.Fatalf("expected at least 2 parts (functionResponse + inline_data), got %d; raw: %s", len(parts), userContent.Raw)
+\t}''',
+    '''\tparts := userContent.Get("parts").Array()
+\tif len(parts) != 1 {
+\t\tt.Fatalf("expected one top-level functionResponse part, got %d; raw: %s", len(parts), userContent.Raw)
+\t}''',
+    'expected one top-level functionResponse part',
+)
+replace_once(
+    gemini_responses_request_test,
+    '''\timg := parts[1].Get("inline_data")
+\tif !img.Exists() {
+\t\tt.Fatalf("expected second part to have inline_data, got %s", parts[1].Raw)
+\t}
+\tif got := img.Get("mime_type").String(); got != "image/png" {
+\t\tt.Fatalf("expected mime_type = %q, got %q", "image/png", got)
+\t}''',
+    '''\timg := fr.Get("parts.0.inlineData")
+\tif !img.Exists() {
+\t\tt.Fatalf("expected image nested under functionResponse.parts, got %s", fr.Raw)
+\t}
+\tif got := img.Get("mimeType").String(); got != "image/png" {
+\t\tt.Fatalf("expected mimeType = %q, got %q", "image/png", got)
+\t}''',
+    'expected image nested under functionResponse.parts',
+)
+replace_once(
+    gemini_responses_request_test,
+    '''\t\tif len(parts) != 2 {
+\t\t\tt.Fatalf("expected 2 parts (functionResponse + inline_data), got %d; raw: %s", len(parts), userContent.Raw)
+\t\t}
+\t\tif got := parts[1].Get("inline_data.mime_type").String(); got != "image/png" {
+\t\t\tt.Fatalf("expected mime_type 'image/png', got %q", got)
+\t\t}
+\t\tif got := parts[1].Get("inline_data.data").String(); got != "iVBORw0KGgoAAAANSUhEUg==" {''',
+    '''\t\tif len(parts) != 1 {
+\t\t\tt.Fatalf("expected one top-level functionResponse part, got %d; raw: %s", len(parts), userContent.Raw)
+\t\t}
+\t\tif got := parts[0].Get("functionResponse.parts.0.inlineData.mimeType").String(); got != "image/png" {
+\t\t\tt.Fatalf("expected nested mimeType 'image/png', got %q", got)
+\t\t}
+\t\tif got := parts[0].Get("functionResponse.parts.0.inlineData.data").String(); got != "iVBORw0KGgoAAAANSUhEUg==" {''',
+    'expected nested mimeType',
+)
+insert_before(
+    gemini_responses_request_test,
+    'func TestConvertOpenAIResponsesRequestToGemini_GroupsNonContiguousParallelToolOutputs(t *testing.T) {',
+    '''func TestConvertOpenAIResponsesRequestToGemini_BindsImagesToParallelFunctionResponses(t *testing.T) {
+\tinputJSON := `{
+\t\t"model":"gemini-3.7-flash-high",
+\t\t"input":[
+\t\t\t{"type":"function_call","call_id":"call-1","name":"first_image","arguments":"{}"},
+\t\t\t{"type":"function_call","call_id":"call-2","name":"second_image","arguments":"{}"},
+\t\t\t{"type":"function_call_output","call_id":"call-1","output":[{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]},
+\t\t\t{"type":"function_call_output","call_id":"call-2","output":[{"type":"input_image","image_url":"data:image/jpeg;base64,BBBB"}]}
+\t\t]
+\t}`
+\tresult := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+\tresponses := gjson.GetBytes(result, "contents.1.parts").Array()
+\tif len(responses) != 2 {
+\t\tt.Fatalf("function response count = %d, want 2; result=%s", len(responses), result)
+\t}
+\twants := []struct {
+\t\tid, mimeType, data string
+\t}{
+\t\t{"call-1", "image/png", "AAAA"},
+\t\t{"call-2", "image/jpeg", "BBBB"},
+\t}
+\tfor index, want := range wants {
+\t\tresponse := responses[index].Get("functionResponse")
+\t\tif got := response.Get("id").String(); got != want.id {
+\t\t\tt.Fatalf("function response %d id = %q, want %q; result=%s", index, got, want.id, result)
+\t\t}
+\t\tif got := response.Get("parts.0.inlineData.mimeType").String(); got != want.mimeType {
+\t\t\tt.Fatalf("function response %d mime type = %q, want %q; result=%s", index, got, want.mimeType, result)
+\t\t}
+\t\tif got := response.Get("parts.0.inlineData.data").String(); got != want.data {
+\t\t\tt.Fatalf("function response %d data = %q, want %q; result=%s", index, got, want.data, result)
+\t\t}
+\t}
+}
+
+''',
+    'func TestConvertOpenAIResponsesRequestToGemini_BindsImagesToParallelFunctionResponses',
+)
+
 # Account policy fields are execution-only overlays. Every Manager-driven
 # incremental scheduler refresh must therefore go through RefreshSchedulerEntry,
 # whose single low-level upsert resolves the latest cached account policy.
@@ -5765,6 +5878,8 @@ format_go_writes([
     'internal/translator/codex/openai/chat-completions/codex_openai_request.go',
     'internal/translator/codex/openai/responses/codex_fast_service_tier_test.go',
     'internal/translator/codex/openai/responses/codex_openai-responses_request.go',
+    'internal/translator/gemini/openai/responses/gemini_openai-responses_request.go',
+    'internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go',
     'sdk/auth/codex_device.go',
     'sdk/auth/filestore.go',
 	'sdk/auth/filestore_identity.go',

--- a/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
+++ b/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
@@ -50,6 +50,8 @@ internal/runtime/executor/xai_executor_stream.go	generic-host-hook	request-obser
 internal/runtime/executor/xai_websockets_executor.go	generic-host-hook	request-observer	upstream-built-in-websocket-response-observer
 internal/translator/codex/openai/chat-completions/codex_openai_request.go	upstream-generic-fix	codex-fast-tier	upstream-forward-fast-service-tier-as-priority
 internal/translator/codex/openai/responses/codex_openai-responses_request.go	upstream-generic-fix	codex-fast-tier	upstream-normalize-fast-service-tier-to-priority
+internal/translator/gemini/openai/responses/gemini_openai-responses_request.go	upstream-generic-fix	vertex-tool-images	upstream-nest-tool-result-images-under-function-response
+internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go	upstream-generic-fix	vertex-tool-images	upstream-nest-tool-result-images-under-function-response
 sdk/api/handlers/claude/code_handlers.go	must-remain-host-patch	final-model-response	retain-request-policy-model-filtering
 sdk/api/handlers/gemini/gemini_handlers.go	must-remain-host-patch	final-model-response	retain-request-policy-model-filtering-and-errors
 sdk/api/handlers/handlers.go	must-remain-host-patch	api-key-policy	retain-policy-visible-model-and-speed-contract

--- a/scripts/validation/contracts/core-upstream-modified-files.txt
+++ b/scripts/validation/contracts/core-upstream-modified-files.txt
@@ -47,6 +47,8 @@ internal/runtime/executor/xai_executor_stream.go
 internal/runtime/executor/xai_websockets_executor.go
 internal/translator/codex/openai/chat-completions/codex_openai_request.go
 internal/translator/codex/openai/responses/codex_openai-responses_request.go
+internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
 sdk/api/handlers/claude/code_handlers.go
 sdk/api/handlers/gemini/gemini_handlers.go
 sdk/api/handlers/handlers.go

--- a/scripts/validation/core.sh
+++ b/scripts/validation/core.sh
@@ -131,6 +131,7 @@ go -C "${upstream_root}" test "${test_flags[@]}" \
   ./internal/translator/codex/claude \
   ./internal/translator/codex/openai/chat-completions \
   ./internal/translator/codex/openai/responses \
+  ./internal/translator/gemini/openai/responses \
   ./internal/pro/... \
   ./sdk/api/handlers \
   ./sdk/api/handlers/claude \

--- a/scripts/validation/test_core_patch_ownership.py
+++ b/scripts/validation/test_core_patch_ownership.py
@@ -15,7 +15,7 @@ ALLOWED_CATEGORIES = {
 
 EXPECTED_CATEGORY_COUNTS = {
     'generic-host-hook': 28,
-    'upstream-generic-fix': 14,
+    'upstream-generic-fix': 16,
     'must-remain-host-patch': 40,
 }
 
@@ -49,7 +49,7 @@ class CorePatchOwnershipContractTest(unittest.TestCase):
         ownership = load_ownership()
         paths = [row['path'] for row in ownership]
 
-        self.assertEqual(82, len(surface))
+        self.assertEqual(84, len(surface))
         self.assertEqual(surface, paths)
         self.assertEqual(len(paths), len(set(paths)))
 


### PR DESCRIPTION
## Summary

- nest direct Gemini/Vertex tool-result images under the matching functionResponse.parts
- preserve MIME type, image bytes, and parallel tool-call association
- track the two patched upstream files and run the Gemini Responses package in core validation

## Why

CLIProxyAPI v7.2.147 emits function_call_output images as top-level sibling inline_data parts. Vertex requires multimodal tool results inside functionResponse.parts and rejects the sibling layout with HTTP 400.

This applies the direct Vertex counterpart of the Antigravity-side correction in router-for-me/CLIProxyAPI#5075 and follows up on router-for-me/CLIProxyAPI#5039.

## Verification

- bash scripts/validation/repo.sh
- Dockerized bash scripts/validation/core.sh against a clean router-for-me/CLIProxyAPI v7.2.147 checkout
  - exact 84-file upstream patch surface matched
  - Gemini OpenAI Responses translator tests passed, including parallel image/tool association
  - complete configured core package suite passed
  - CGO and non-CGO server binaries built successfully
- git diff --check