### PR TITLE
fix(core): make Codex 429 responses retryable

### DIFF
--- a/cliproxyapi-pro-core/patches/apply_upstream_patches.py
+++ b/cliproxyapi-pro-core/patches/apply_upstream_patches.py
@@ -2641,6 +2641,174 @@ replace_once(
     'meta[coreexecutor.SpeedMetadataKey] = speed',
 )
 
+handlers_error_response_test_source = ROOT / 'sdk/api/handlers/handlers_error_response_test.go'
+add_go_import(handlers_error_response_test_source, '"bytes"\n', '\t"encoding/json"\n')
+insert_before(
+    handlers_error_response_test_source,
+    'func TestWriteErrorResponse_AddonHeadersDisabledByDefault(t *testing.T) {\n',
+    '''func TestBuildErrorResponseBody_NormalizesNonCanonicalRateLimitJSON(t *testing.T) {
+	body := BuildErrorResponseBody(http.StatusTooManyRequests, `{"detail":"Rate limit exceeded"}`)
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("body is not valid JSON: %v; body=%s", err, body)
+	}
+	if payload.Error.Message != "Rate limit exceeded" {
+		t.Fatalf("error.message = %q, want %q", payload.Error.Message, "Rate limit exceeded")
+	}
+	if payload.Error.Type != "rate_limit_error" {
+		t.Fatalf("error.type = %q, want rate_limit_error", payload.Error.Type)
+	}
+	if payload.Error.Code != "rate_limit_exceeded" {
+		t.Fatalf("error.code = %q, want rate_limit_exceeded", payload.Error.Code)
+	}
+}
+
+func TestBuildErrorResponseBody_PreservesCanonicalRateLimitFields(t *testing.T) {
+	body := BuildErrorResponseBody(http.StatusTooManyRequests, `{"error":{"type":"usage_limit_reached","code":"usage_limit","resets_in_seconds":120}}`)
+	var payload struct {
+		Error struct {
+			Type            string `json:"type"`
+			Code            string `json:"code"`
+			ResetsInSeconds int    `json:"resets_in_seconds"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("body is not valid JSON: %v; body=%s", err, body)
+	}
+	if payload.Error.Type != "usage_limit_reached" || payload.Error.Code != "usage_limit" || payload.Error.ResetsInSeconds != 120 {
+		t.Fatalf("canonical rate limit fields were not preserved: %+v", payload.Error)
+	}
+}
+
+''',
+    'func TestBuildErrorResponseBody_NormalizesNonCanonicalRateLimitJSON(',
+)
+
+replace_once(
+    handlers_source,
+    '// If errText is already valid JSON, it is returned as-is to preserve upstream error payloads.\n',
+    '// Valid non-429 JSON is preserved. A 429 is normalized into an OpenAI-compatible\n// error envelope so Codex clients can recognize the rate-limit retry signal.\n',
+    'A 429 is normalized into an OpenAI-compatible',
+)
+
+replace_go_function(
+    handlers_source,
+    'func BuildErrorResponseBody(status int, errText string) []byte',
+    '''func BuildErrorResponseBody(status int, errText string) []byte {
+	if status <= 0 {
+		status = http.StatusInternalServerError
+	}
+	if strings.TrimSpace(errText) == "" {
+		errText = http.StatusText(status)
+	}
+
+	trimmed := strings.TrimSpace(errText)
+	if trimmed != "" && json.Valid([]byte(trimmed)) {
+		if status == http.StatusTooManyRequests {
+			if normalized := normalizeRateLimitErrorBody(trimmed); len(normalized) > 0 {
+				return normalized
+			}
+		} else {
+			return []byte(trimmed)
+		}
+	}
+
+	errType := "invalid_request_error"
+	var code string
+	switch status {
+	case http.StatusUnauthorized:
+		errType = "authentication_error"
+		code = "invalid_api_key"
+	case http.StatusForbidden:
+		errType = "permission_error"
+		code = "insufficient_quota"
+	case http.StatusTooManyRequests:
+		errType = "rate_limit_error"
+		code = "rate_limit_exceeded"
+	case http.StatusNotFound:
+		errType = "invalid_request_error"
+		code = "model_not_found"
+	default:
+		if status >= http.StatusInternalServerError {
+			errType = "server_error"
+			code = "internal_server_error"
+		}
+	}
+
+	payload, err := json.Marshal(ErrorResponse{
+		Error: ErrorDetail{
+			Message: errText,
+			Type:    errType,
+			Code:    code,
+		},
+	})
+	if err != nil {
+		return []byte(fmt.Sprintf(`{"error":{"message":%q,"type":"server_error","code":"internal_server_error"}}`, errText))
+	}
+	return payload
+}
+''',
+    'func normalizeRateLimitErrorBody',
+)
+
+insert_before(
+    handlers_source,
+    '// StreamingKeepAliveInterval returns the SSE keep-alive interval for this server.\n',
+    '''func normalizeRateLimitErrorBody(errText string) []byte {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(errText), &payload); err != nil {
+		return nil
+	}
+
+	errorObject, _ := payload["error"].(map[string]any)
+	if errorObject == nil {
+		errorObject = make(map[string]any)
+	}
+
+	message, _ := errorObject["message"].(string)
+	if strings.TrimSpace(message) == "" {
+		if value, ok := payload["error"].(string); ok {
+			message = value
+		}
+	}
+	if strings.TrimSpace(message) == "" {
+		for _, key := range []string{"message", "detail"} {
+			if value, ok := payload[key].(string); ok && strings.TrimSpace(value) != "" {
+				message = value
+				break
+			}
+		}
+	}
+	if strings.TrimSpace(message) == "" {
+		message = http.StatusText(http.StatusTooManyRequests)
+	}
+	errorObject["message"] = message
+
+	if value, ok := errorObject["type"].(string); !ok || strings.TrimSpace(value) == "" {
+		errorObject["type"] = "rate_limit_error"
+	}
+	if value, ok := errorObject["code"].(string); !ok || strings.TrimSpace(value) == "" {
+		errorObject["code"] = "rate_limit_exceeded"
+	}
+	payload["error"] = errorObject
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	return normalized
+}
+
+''',
+    'func normalizeRateLimitErrorBody',
+)
+
 codex_chat_completions_request = ROOT / 'internal/translator/codex/openai/chat-completions/codex_openai_request.go'
 replace_once(
     codex_chat_completions_request,
@@ -5885,6 +6053,7 @@ format_go_writes([
 	'sdk/auth/filestore_identity.go',
 	'sdk/auth/filestore_identity_test.go',
     'sdk/api/handlers/handlers.go',
+    'sdk/api/handlers/handlers_error_response_test.go',
     'sdk/api/handlers/api_key_policy_test.go',
 	'sdk/api/handlers/api_key_policy_context_test.go',
     'sdk/api/handlers/handlers_context.go',

--- a/cliproxyapi-pro-core/patches/apply_upstream_patches.py
+++ b/cliproxyapi-pro-core/patches/apply_upstream_patches.py
@@ -95,6 +95,16 @@ def replace_once(path: Path, old: str, new: str, present=None) -> None:
     write(path, text.replace(old, new, 1))
 
 
+def replace_all(path: Path, old: str, new: str, present=None) -> None:
+    text = read(path)
+    if (present or new) and (present or new) in text:
+        return
+    match_count = text.count(old)
+    if match_count == 0:
+        raise SystemExit(f'expected at least one pattern in {path}, found none: {old[:120]!r}')
+    write(path, text.replace(old, new))
+
+
 def insert_before(path: Path, marker: str, insertion: str, present: str) -> None:
     text = read(path)
     if present in text:
@@ -250,6 +260,9 @@ new_customization_paths = (
 	'internal/api/server_model_policy.go',
 	'internal/runtime/executor/helps/quota_settlement_test.go',
 	'internal/runtime/executor/helps/usage_pro_extensions.go',
+	'internal/runtime/executor/helps/retry_after.go',
+	'internal/runtime/executor/helps/retry_after_test.go',
+	'internal/runtime/executor/codex_retry_after_test.go',
     'internal/runtime/executor/helps/usage_speed_test.go',
 	'internal/runtime/executor/claude_usage_speed_test.go',
 	'internal/runtime/executor/claude_stream_terminal.go',
@@ -275,6 +288,7 @@ new_customization_paths = (
     'sdk/cliproxy/auth/auth_runtime_state_test.go',
 	'sdk/cliproxy/auth/auth_account_policy.go',
 	'sdk/cliproxy/auth/auth_account_policy_test.go',
+	'sdk/cliproxy/auth/codex_retry_after_headers_test.go',
 	'sdk/cliproxy/auth/scheduler_runtime_state.go',
     'sdk/cliproxy/auth/inspection_refresh.go',
     'sdk/cliproxy/auth/pinned_execution.go',
@@ -299,6 +313,9 @@ queue_go_source('sdk/auth/filestore_identity_test.go')
 queue_go_source('internal/runtime/executor/api_key_policy_usage_test.go')
 queue_go_source('internal/runtime/executor/helps/quota_settlement_test.go')
 queue_go_source('internal/runtime/executor/helps/usage_pro_extensions.go')
+queue_go_source('internal/runtime/executor/helps/retry_after.go')
+queue_go_source('internal/runtime/executor/helps/retry_after_test.go')
+queue_go_source('internal/runtime/executor/codex_retry_after_test.go')
 queue_go_source('internal/runtime/executor/response_translation.go')
 queue_go_source('internal/pro/observability/config_test.go')
 queue_go_source('sdk/cliproxy/usage/manager_pro_test.go')
@@ -307,6 +324,116 @@ queue_go_source('internal/pluginhost/plugin_executor_usage.go')
 queue_go_source('sdk/auth/filestore_identity.go')
 queue_go_source('sdk/cliproxy/auth/scheduler_runtime_state.go')
 queue_go_source('internal/runtime/executor/claude_stream_terminal.go')
+queue_go_source('sdk/cliproxy/auth/codex_retry_after_headers_test.go')
+
+codex_terminal = ROOT / 'internal/runtime/executor/codex_executor_terminal.go'
+replace_go_function(
+    codex_terminal,
+    'func newCodexStatusErr(statusCode int, body []byte) statusErr',
+    '''func newCodexStatusErr(statusCode int, body []byte, responseHeaders ...http.Header) statusErr {
+	errCode := statusCode
+	if isCodexModelCapacityError(body) || isCodexUsageLimitError(body) {
+		errCode = http.StatusTooManyRequests
+	}
+	body = classifyCodexStatusError(errCode, body)
+	retryAfter := parseCodexRetryAfter(errCode, body, time.Now())
+	if retryAfter == nil && len(responseHeaders) > 0 {
+		retryAfter = helps.ParseRetryAfterHeader(responseHeaders[0].Get("Retry-After"), time.Now())
+	}
+	if retryAfter == nil && errCode == http.StatusTooManyRequests && !isCodexModelCapacityError(body) {
+		fallback := 10 * time.Second
+		retryAfter = &fallback
+	}
+	err := statusErr{code: errCode, msg: string(body), retryAfter: retryAfter}
+	return err
+}
+''',
+    'helps.ParseRetryAfterHeader(responseHeaders[0].Get("Retry-After"), time.Now())',
+)
+
+codex_execute = ROOT / 'internal/runtime/executor/codex_executor_execute.go'
+replace_all(
+    codex_execute,
+    'newCodexStatusErr(httpResp.StatusCode, b)',
+    'newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)',
+    'newCodexStatusErr(httpResp.StatusCode, b, httpResp.Header)',
+)
+
+codex_images = ROOT / 'internal/runtime/executor/codex_openai_images.go'
+replace_all(
+    codex_images,
+    'newCodexStatusErr(httpResp.StatusCode, data)',
+    'newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)',
+    'newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)',
+)
+
+codex_stream = ROOT / 'internal/runtime/executor/codex_executor_stream.go'
+replace_once(
+    codex_stream,
+    'newCodexStatusErr(httpResp.StatusCode, data)',
+    'newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)',
+    'newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)',
+)
+
+codex_websocket_execute = ROOT / 'internal/runtime/executor/codex_websockets_execute.go'
+replace_once(
+    codex_websocket_execute,
+    'newCodexStatusErr(respHS.StatusCode, bodyErr)',
+    'newCodexStatusErr(respHS.StatusCode, bodyErr, respHS.Header)',
+    'newCodexStatusErr(respHS.StatusCode, bodyErr, respHS.Header)',
+)
+
+codex_websocket_stream = ROOT / 'internal/runtime/executor/codex_websockets_stream.go'
+replace_once(
+    codex_websocket_stream,
+    'newCodexStatusErr(respHS.StatusCode, bodyErr)',
+    'newCodexStatusErr(respHS.StatusCode, bodyErr, respHS.Header)',
+    'newCodexStatusErr(respHS.StatusCode, bodyErr, respHS.Header)',
+)
+
+home_concurrency = ROOT / 'sdk/cliproxy/auth/home_concurrency.go'
+replace_go_function(
+    home_concurrency,
+    'func SafeResponseHeaders(err error) http.Header',
+    '''func SafeResponseHeaders(err error) http.Header {
+	var busy *HomeConcurrencyBusyError
+	if errors.As(err, &busy) && busy != nil {
+		return busy.SafeResponseHeaders()
+	}
+	var exhausted *homeRetryRoundExhaustedError
+	if errors.As(err, &exhausted) && exhausted != nil {
+		retryAfter := exhausted.RetryAfter()
+		if retryAfter == nil {
+			return nil
+		}
+		return safeRetryAfterHeader(*retryAfter)
+	}
+	var cooldown *homeDispatchRetryAfterError
+	if errors.As(err, &cooldown) && cooldown != nil {
+		retryAfter := cooldown.RetryAfter()
+		if retryAfter == nil {
+			return nil
+		}
+		return safeRetryAfterHeader(*retryAfter)
+	}
+	var modelCooldown *modelCooldownError
+	if errors.As(err, &modelCooldown) && modelCooldown != nil {
+		return modelCooldown.Headers()
+	}
+	var retryAfterStatusErr interface {
+		StatusCode() int
+		RetryAfter() *time.Duration
+	}
+	if errors.As(err, &retryAfterStatusErr) && retryAfterStatusErr != nil && retryAfterStatusErr.StatusCode() == http.StatusTooManyRequests {
+		if retryAfter := retryAfterStatusErr.RetryAfter(); retryAfter != nil {
+			return safeRetryAfterHeader(*retryAfter)
+		}
+	}
+	return nil
+}
+''',
+    'var retryAfterStatusErr interface',
+)
 
 codex_device = ROOT / 'sdk/auth/codex_device.go'
 replace_once(
@@ -5934,13 +6061,24 @@ format_go_writes([
     'internal/runtime/executor/helps/logging_helpers.go',
 	'internal/runtime/executor/helps/quota_settlement_test.go',
 	'internal/runtime/executor/helps/usage_pro_extensions.go',
-    'internal/runtime/executor/helps/response_observer_test.go',
+	'internal/runtime/executor/helps/retry_after.go',
+	'internal/runtime/executor/helps/retry_after_test.go',
+	'internal/runtime/executor/helps/response_observer_test.go',
     'internal/runtime/executor/helps/usage_helpers.go',
     'internal/runtime/executor/helps/usage_speed_test.go',
     'internal/runtime/executor/claude_usage_speed_test.go',
     'internal/runtime/executor/claude_executor_execute.go',
     'internal/runtime/executor/claude_executor_stream.go',
-    'internal/runtime/executor/claude_stream_terminal.go',
+	'internal/runtime/executor/claude_stream_terminal.go',
+	'internal/runtime/executor/codex_executor_terminal.go',
+	'internal/runtime/executor/codex_executor_execute.go',
+	'internal/runtime/executor/codex_openai_images.go',
+	'internal/runtime/executor/codex_executor_stream.go',
+	'internal/runtime/executor/codex_websockets_execute.go',
+	'internal/runtime/executor/codex_websockets_stream.go',
+	'internal/runtime/executor/codex_retry_after_test.go',
+	'sdk/cliproxy/auth/home_concurrency.go',
+	'sdk/cliproxy/auth/codex_retry_after_headers_test.go',
     'internal/pro/oauthpolicy/config/config.go',
     'internal/pro/oauthpolicy/config/config_test.go',
     'internal/pro/oauthpolicy/policy/engine.go',

--- a/cliproxyapi-pro-core/patches/apply_upstream_patches.py
+++ b/cliproxyapi-pro-core/patches/apply_upstream_patches.py
@@ -5565,6 +5565,119 @@ replace_once(
     's.persistMixedCursor(persistedCursorKey, picked.ID)',
 )
 
+# Vertex requires multimodal tool results to live inside the corresponding
+# functionResponse. Top-level sibling inline_data parts make the request end in
+# an invalid model turn and are rejected with HTTP 400.
+gemini_responses_request = ROOT / 'internal/translator/gemini/openai/responses/gemini_openai-responses_request.go'
+replace_once(
+    gemini_responses_request,
+    '''\tparts := make([][]byte, 0, 1+len(imageParts))
+\tparts = append(parts, functionResponse)
+\tparts = append(parts, imageParts...)
+\treturn parts
+''',
+    '''\tfor _, imagePart := range imageParts {
+\t\tinlineData := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+\t\tinlineData, _ = sjson.SetBytes(inlineData, "inlineData.mimeType", gjson.GetBytes(imagePart, "inline_data.mime_type").String())
+\t\tinlineData, _ = sjson.SetBytes(inlineData, "inlineData.data", gjson.GetBytes(imagePart, "inline_data.data").String())
+\t\tfunctionResponse, _ = sjson.SetRawBytes(functionResponse, "functionResponse.parts.-1", inlineData)
+\t}
+\treturn [][]byte{functionResponse}
+''',
+    'functionResponse.parts.-1',
+)
+
+gemini_responses_request_test = ROOT / 'internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go'
+replace_once(
+    gemini_responses_request_test,
+    '''\tparts := userContent.Get("parts").Array()
+\tif len(parts) < 2 {
+\t\tt.Fatalf("expected at least 2 parts (functionResponse + inline_data), got %d; raw: %s", len(parts), userContent.Raw)
+\t}''',
+    '''\tparts := userContent.Get("parts").Array()
+\tif len(parts) != 1 {
+\t\tt.Fatalf("expected one top-level functionResponse part, got %d; raw: %s", len(parts), userContent.Raw)
+\t}''',
+    'expected one top-level functionResponse part',
+)
+replace_once(
+    gemini_responses_request_test,
+    '''\timg := parts[1].Get("inline_data")
+\tif !img.Exists() {
+\t\tt.Fatalf("expected second part to have inline_data, got %s", parts[1].Raw)
+\t}
+\tif got := img.Get("mime_type").String(); got != "image/png" {
+\t\tt.Fatalf("expected mime_type = %q, got %q", "image/png", got)
+\t}''',
+    '''\timg := fr.Get("parts.0.inlineData")
+\tif !img.Exists() {
+\t\tt.Fatalf("expected image nested under functionResponse.parts, got %s", fr.Raw)
+\t}
+\tif got := img.Get("mimeType").String(); got != "image/png" {
+\t\tt.Fatalf("expected mimeType = %q, got %q", "image/png", got)
+\t}''',
+    'expected image nested under functionResponse.parts',
+)
+replace_once(
+    gemini_responses_request_test,
+    '''\t\tif len(parts) != 2 {
+\t\t\tt.Fatalf("expected 2 parts (functionResponse + inline_data), got %d; raw: %s", len(parts), userContent.Raw)
+\t\t}
+\t\tif got := parts[1].Get("inline_data.mime_type").String(); got != "image/png" {
+\t\t\tt.Fatalf("expected mime_type 'image/png', got %q", got)
+\t\t}
+\t\tif got := parts[1].Get("inline_data.data").String(); got != "iVBORw0KGgoAAAANSUhEUg==" {''',
+    '''\t\tif len(parts) != 1 {
+\t\t\tt.Fatalf("expected one top-level functionResponse part, got %d; raw: %s", len(parts), userContent.Raw)
+\t\t}
+\t\tif got := parts[0].Get("functionResponse.parts.0.inlineData.mimeType").String(); got != "image/png" {
+\t\t\tt.Fatalf("expected nested mimeType 'image/png', got %q", got)
+\t\t}
+\t\tif got := parts[0].Get("functionResponse.parts.0.inlineData.data").String(); got != "iVBORw0KGgoAAAANSUhEUg==" {''',
+    'expected nested mimeType',
+)
+insert_before(
+    gemini_responses_request_test,
+    'func TestConvertOpenAIResponsesRequestToGemini_GroupsNonContiguousParallelToolOutputs(t *testing.T) {',
+    '''func TestConvertOpenAIResponsesRequestToGemini_BindsImagesToParallelFunctionResponses(t *testing.T) {
+\tinputJSON := `{
+\t\t"model":"gemini-3.7-flash-high",
+\t\t"input":[
+\t\t\t{"type":"function_call","call_id":"call-1","name":"first_image","arguments":"{}"},
+\t\t\t{"type":"function_call","call_id":"call-2","name":"second_image","arguments":"{}"},
+\t\t\t{"type":"function_call_output","call_id":"call-1","output":[{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]},
+\t\t\t{"type":"function_call_output","call_id":"call-2","output":[{"type":"input_image","image_url":"data:image/jpeg;base64,BBBB"}]}
+\t\t]
+\t}`
+\tresult := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+\tresponses := gjson.GetBytes(result, "contents.1.parts").Array()
+\tif len(responses) != 2 {
+\t\tt.Fatalf("function response count = %d, want 2; result=%s", len(responses), result)
+\t}
+\twants := []struct {
+\t\tid, mimeType, data string
+\t}{
+\t\t{"call-1", "image/png", "AAAA"},
+\t\t{"call-2", "image/jpeg", "BBBB"},
+\t}
+\tfor index, want := range wants {
+\t\tresponse := responses[index].Get("functionResponse")
+\t\tif got := response.Get("id").String(); got != want.id {
+\t\t\tt.Fatalf("function response %d id = %q, want %q; result=%s", index, got, want.id, result)
+\t\t}
+\t\tif got := response.Get("parts.0.inlineData.mimeType").String(); got != want.mimeType {
+\t\t\tt.Fatalf("function response %d mime type = %q, want %q; result=%s", index, got, want.mimeType, result)
+\t\t}
+\t\tif got := response.Get("parts.0.inlineData.data").String(); got != want.data {
+\t\t\tt.Fatalf("function response %d data = %q, want %q; result=%s", index, got, want.data, result)
+\t\t}
+\t}
+}
+
+''',
+    'func TestConvertOpenAIResponsesRequestToGemini_BindsImagesToParallelFunctionResponses',
+)
+
 # Account policy fields are execution-only overlays. Every Manager-driven
 # incremental scheduler refresh must therefore go through RefreshSchedulerEntry,
 # whose single low-level upsert resolves the latest cached account policy.
@@ -5765,6 +5878,8 @@ format_go_writes([
     'internal/translator/codex/openai/chat-completions/codex_openai_request.go',
     'internal/translator/codex/openai/responses/codex_fast_service_tier_test.go',
     'internal/translator/codex/openai/responses/codex_openai-responses_request.go',
+    'internal/translator/gemini/openai/responses/gemini_openai-responses_request.go',
+    'internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go',
     'sdk/auth/codex_device.go',
     'sdk/auth/filestore.go',
 	'sdk/auth/filestore_identity.go',

--- a/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/codex_retry_after_test.go
+++ b/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/codex_retry_after_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewCodexStatusErrRetryAfterPrecedence(t *testing.T) {
+	body := []byte(`{"error":{"type":"usage_limit_reached","resets_in_seconds":120}}`)
+	err := newCodexStatusErr(http.StatusTooManyRequests, body, http.Header{"Retry-After": []string{"5"}})
+
+	if retryAfter := err.RetryAfter(); retryAfter == nil || *retryAfter != 120*time.Second {
+		t.Fatalf("body reset did not take precedence: RetryAfter() = %v, want 2m", retryAfter)
+	}
+}
+
+func TestNewCodexStatusErrUsesRetryAfterHeader(t *testing.T) {
+	err := newCodexStatusErr(
+		http.StatusTooManyRequests,
+		[]byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`),
+		http.Header{"Retry-After": []string{"37"}},
+	)
+
+	if retryAfter := err.RetryAfter(); retryAfter == nil || *retryAfter != 37*time.Second {
+		t.Fatalf("RetryAfter() = %v, want 37s", retryAfter)
+	}
+}
+
+func TestNewCodexStatusErrUsesSafeFallback(t *testing.T) {
+	err := newCodexStatusErr(http.StatusTooManyRequests, []byte(`{"detail":"Rate limit exceeded"}`))
+
+	if retryAfter := err.RetryAfter(); retryAfter == nil || *retryAfter != 10*time.Second {
+		t.Fatalf("RetryAfter() = %v, want 10s fallback", retryAfter)
+	}
+}

--- a/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/helps/retry_after.go
+++ b/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/helps/retry_after.go
@@ -1,0 +1,34 @@
+package helps
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseRetryAfterHeader parses the standard Retry-After formats into a positive delay.
+// Invalid, expired, and empty values return nil so callers can apply a safe fallback.
+func ParseRetryAfterHeader(raw string, now time.Time) *time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if seconds, err := strconv.ParseFloat(raw, 64); err == nil && seconds > 0 {
+		delay := time.Duration(seconds * float64(time.Second))
+		if delay > 0 {
+			return &delay
+		}
+	}
+	if resetAt, err := http.ParseTime(raw); err == nil {
+		if delay := resetAt.Sub(now); delay > 0 {
+			return &delay
+		}
+	}
+	if resetAt, err := time.Parse(time.RFC3339, raw); err == nil {
+		if delay := resetAt.Sub(now); delay > 0 {
+			return &delay
+		}
+	}
+	return nil
+}

--- a/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/helps/retry_after_test.go
+++ b/cliproxyapi-pro-core/patches/sources/internal/runtime/executor/helps/retry_after_test.go
@@ -1,0 +1,37 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfterHeader(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	futureHTTPDate := now.Add(45 * time.Second).UTC().Format(http.TimeFormat)
+	futureRFC3339 := now.Add(90 * time.Second).Format(time.RFC3339)
+
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "seconds", raw: "12", want: 12 * time.Second},
+		{name: "http date", raw: futureHTTPDate, want: 45 * time.Second},
+		{name: "rfc3339", raw: futureRFC3339, want: 90 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseRetryAfterHeader(tc.raw, now)
+			if got == nil || *got != tc.want {
+				t.Fatalf("ParseRetryAfterHeader(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+
+	for _, raw := range []string{"", "0", "invalid", now.Add(-time.Second).UTC().Format(http.TimeFormat)} {
+		if got := ParseRetryAfterHeader(raw, now); got != nil {
+			t.Fatalf("ParseRetryAfterHeader(%q) = %v, want nil", raw, *got)
+		}
+	}
+}

--- a/cliproxyapi-pro-core/patches/sources/sdk/cliproxy/auth/codex_retry_after_headers_test.go
+++ b/cliproxyapi-pro-core/patches/sources/sdk/cliproxy/auth/codex_retry_after_headers_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+type codexRetryAfterHeadersTestError struct {
+	retryAfter time.Duration
+}
+
+func (e codexRetryAfterHeadersTestError) Error() string { return "codex rate limit" }
+func (e codexRetryAfterHeadersTestError) StatusCode() int {
+	return http.StatusTooManyRequests
+}
+func (e codexRetryAfterHeadersTestError) RetryAfter() *time.Duration {
+	return &e.retryAfter
+}
+
+func TestSafeResponseHeadersIncludesRetryAfterProvider(t *testing.T) {
+	err := codexRetryAfterHeadersTestError{retryAfter: 10 * time.Second}
+	if got := SafeResponseHeaders(err).Get("Retry-After"); got != "10" {
+		t.Fatalf("Retry-After = %q, want 10", got)
+	}
+}

--- a/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
+++ b/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
@@ -41,6 +41,12 @@ internal/pluginstore/auth.go	upstream-generic-fix	plugin-store-auth	upstream-pri
 internal/redisqueue/plugin.go	must-remain-host-patch	observability	retain-usage-enrichment-and-monitoring-controls
 internal/runtime/executor/claude_executor_execute.go	upstream-generic-fix	usage-accounting	upstream-preserve-claude-failed-usage
 internal/runtime/executor/claude_executor_stream.go	upstream-generic-fix	usage-accounting	upstream-preserve-claude-stream-failed-usage
+internal/runtime/executor/codex_executor_execute.go	upstream-generic-fix	codex-rate-limit-retry	upstream-forward-codex-retry-after-through-http-execution
+internal/runtime/executor/codex_executor_stream.go	upstream-generic-fix	codex-rate-limit-retry	upstream-forward-codex-retry-after-through-stream-execution
+internal/runtime/executor/codex_executor_terminal.go	upstream-generic-fix	codex-rate-limit-retry	upstream-parse-body-header-and-safe-fallback-retry-timing
+internal/runtime/executor/codex_openai_images.go	upstream-generic-fix	codex-rate-limit-retry	upstream-forward-codex-retry-after-through-image-execution
+internal/runtime/executor/codex_websockets_execute.go	upstream-generic-fix	codex-rate-limit-retry	upstream-forward-codex-retry-after-through-websocket-execution
+internal/runtime/executor/codex_websockets_stream.go	upstream-generic-fix	codex-rate-limit-retry	upstream-forward-codex-retry-after-through-websocket-stream
 internal/runtime/executor/helps/logging_helpers.go	generic-host-hook	request-observer	upstream-final-response-observer
 internal/runtime/executor/helps/usage_helpers.go	must-remain-host-patch	api-key-policy	retain-synchronous-quota-settlement-while-upstreaming-usage-fixes
 internal/runtime/executor/openai_compat_executor.go	upstream-generic-fix	usage-accounting	upstream-terminal-usage-publication-correctness
@@ -72,6 +78,7 @@ sdk/cliproxy/auth/conductor_lifecycle.go	generic-host-hook	auth-lifecycle	upstre
 sdk/cliproxy/auth/conductor_refresh.go	upstream-generic-fix	scheduler	upstream-centralized-scheduler-refresh
 sdk/cliproxy/auth/conductor_selection.go	generic-host-hook	account-policy	upstream-auth-overlay-and-selection-observer
 sdk/cliproxy/auth/conductor_stream.go	generic-host-hook	usage-accounting	upstream-stream-attempt-context
+sdk/cliproxy/auth/home_concurrency.go	upstream-generic-fix	codex-rate-limit-retry	upstream-expose-safe-retry-after-from-codex-status-errors
 sdk/cliproxy/auth/scheduler.go	must-remain-host-patch	scheduler-runtime-state	retain-routing-cursor-persistence-and-runtime-state
 sdk/cliproxy/auth/selector.go	must-remain-host-patch	scheduler-runtime-state	retain-cursor-selection-semantics
 sdk/cliproxy/auth/types.go	must-remain-host-patch	scheduler-runtime-state	retain-auth-runtime-counters

--- a/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
+++ b/scripts/validation/contracts/core-upstream-modified-files.ownership.tsv
@@ -50,6 +50,8 @@ internal/runtime/executor/xai_executor_stream.go	generic-host-hook	request-obser
 internal/runtime/executor/xai_websockets_executor.go	generic-host-hook	request-observer	upstream-built-in-websocket-response-observer
 internal/translator/codex/openai/chat-completions/codex_openai_request.go	upstream-generic-fix	codex-fast-tier	upstream-forward-fast-service-tier-as-priority
 internal/translator/codex/openai/responses/codex_openai-responses_request.go	upstream-generic-fix	codex-fast-tier	upstream-normalize-fast-service-tier-to-priority
+internal/translator/gemini/openai/responses/gemini_openai-responses_request.go	upstream-generic-fix	vertex-tool-images	upstream-nest-tool-result-images-under-function-response
+internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go	upstream-generic-fix	vertex-tool-images	upstream-nest-tool-result-images-under-function-response
 sdk/api/handlers/claude/code_handlers.go	must-remain-host-patch	final-model-response	retain-request-policy-model-filtering
 sdk/api/handlers/gemini/gemini_handlers.go	must-remain-host-patch	final-model-response	retain-request-policy-model-filtering-and-errors
 sdk/api/handlers/handlers.go	must-remain-host-patch	api-key-policy	retain-policy-visible-model-and-speed-contract

--- a/scripts/validation/contracts/core-upstream-modified-files.txt
+++ b/scripts/validation/contracts/core-upstream-modified-files.txt
@@ -38,6 +38,12 @@ internal/pluginstore/auth.go
 internal/redisqueue/plugin.go
 internal/runtime/executor/claude_executor_execute.go
 internal/runtime/executor/claude_executor_stream.go
+internal/runtime/executor/codex_executor_execute.go
+internal/runtime/executor/codex_executor_stream.go
+internal/runtime/executor/codex_executor_terminal.go
+internal/runtime/executor/codex_openai_images.go
+internal/runtime/executor/codex_websockets_execute.go
+internal/runtime/executor/codex_websockets_stream.go
 internal/runtime/executor/helps/logging_helpers.go
 internal/runtime/executor/helps/usage_helpers.go
 internal/runtime/executor/openai_compat_executor.go
@@ -69,6 +75,7 @@ sdk/cliproxy/auth/conductor_lifecycle.go
 sdk/cliproxy/auth/conductor_refresh.go
 sdk/cliproxy/auth/conductor_selection.go
 sdk/cliproxy/auth/conductor_stream.go
+sdk/cliproxy/auth/home_concurrency.go
 sdk/cliproxy/auth/scheduler.go
 sdk/cliproxy/auth/selector.go
 sdk/cliproxy/auth/types.go

--- a/scripts/validation/contracts/core-upstream-modified-files.txt
+++ b/scripts/validation/contracts/core-upstream-modified-files.txt
@@ -47,6 +47,8 @@ internal/runtime/executor/xai_executor_stream.go
 internal/runtime/executor/xai_websockets_executor.go
 internal/translator/codex/openai/chat-completions/codex_openai_request.go
 internal/translator/codex/openai/responses/codex_openai-responses_request.go
+internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
 sdk/api/handlers/claude/code_handlers.go
 sdk/api/handlers/gemini/gemini_handlers.go
 sdk/api/handlers/handlers.go

--- a/scripts/validation/core.sh
+++ b/scripts/validation/core.sh
@@ -131,6 +131,7 @@ go -C "${upstream_root}" test "${test_flags[@]}" \
   ./internal/translator/codex/claude \
   ./internal/translator/codex/openai/chat-completions \
   ./internal/translator/codex/openai/responses \
+  ./internal/translator/gemini/openai/responses \
   ./internal/pro/... \
   ./sdk/api/handlers \
   ./sdk/api/handlers/claude \

--- a/scripts/validation/test_core_patch_ownership.py
+++ b/scripts/validation/test_core_patch_ownership.py
@@ -15,7 +15,7 @@ ALLOWED_CATEGORIES = {
 
 EXPECTED_CATEGORY_COUNTS = {
     'generic-host-hook': 28,
-    'upstream-generic-fix': 16,
+    'upstream-generic-fix': 23,
     'must-remain-host-patch': 40,
 }
 
@@ -49,7 +49,7 @@ class CorePatchOwnershipContractTest(unittest.TestCase):
         ownership = load_ownership()
         paths = [row['path'] for row in ownership]
 
-        self.assertEqual(84, len(surface))
+        self.assertEqual(91, len(surface))
         self.assertEqual(surface, paths)
         self.assertEqual(len(paths), len(set(paths)))
 

--- a/scripts/validation/test_core_patch_ownership.py
+++ b/scripts/validation/test_core_patch_ownership.py
@@ -15,7 +15,7 @@ ALLOWED_CATEGORIES = {
 
 EXPECTED_CATEGORY_COUNTS = {
     'generic-host-hook': 28,
-    'upstream-generic-fix': 14,
+    'upstream-generic-fix': 16,
     'must-remain-host-patch': 40,
 }
 
@@ -49,7 +49,7 @@ class CorePatchOwnershipContractTest(unittest.TestCase):
         ownership = load_ownership()
         paths = [row['path'] for row in ownership]
 
-        self.assertEqual(82, len(surface))
+        self.assertEqual(84, len(surface))
         self.assertEqual(surface, paths)
         self.assertEqual(len(paths), len(set(paths)))
 


### PR DESCRIPTION
Combines the Codex rate-limit fixes from 1eff93b and 9a3995f.

- Normalize non-canonical 429 JSON into an OpenAI-compatible error envelope.
- Preserve Retry-After/reset timing through Codex execution and response headers.
- Add focused regression coverage for handlers, executor, and auth.

Validation: patched upstream tree passes go test ./sdk/api/handlers ./internal/runtime/executor ./sdk/cliproxy/auth. The combined binary was deployed to the MSQAX CLIProxyAPI-Pro service as v7.2.147-pro-hotfix.3b2ebea; health endpoint and post-restart responses are healthy.